### PR TITLE
[Week1] 권영태

### DIFF
--- a/youngtae/week1/Week1_2573.java
+++ b/youngtae/week1/Week1_2573.java
@@ -1,0 +1,142 @@
+package week1;
+
+import java.io.*;
+import java.util.*;
+
+public class Week1_2573 {
+
+	static int N, M, year, area, size;
+	static int[] dx = {0, 1, 0, -1};
+	static int[] dy = {1, 0, -1, 0};
+	static int[][] map, tmp;
+	static boolean[][] visited;
+	static Queue<int[]> q = new LinkedList<>();
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringBuilder sb = new StringBuilder();
+
+		StringTokenizer str = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(str.nextToken());
+		M = Integer.parseInt(str.nextToken());
+
+		map = new int[N][M];		// 빙산 지도 배열
+		tmp = new int[N][M];		// 빙산를 한번에 녹이기 위해, 각 빙산이 줄어들 크기 저장 배열
+		visited = new boolean[N][M];
+
+		for(int i = 0; i < N; i++) {
+			str = new StringTokenizer(br.readLine());
+			for(int j = 0; j < M; j++) {
+				int status = Integer.parseInt(str.nextToken());
+
+				if(status != 0) {		// 바다가 아닌 빙산는 바로 Queue에 삽입
+					q.add(new int[] {i, j});
+				}
+				map[i][j] = status;
+			}
+		}
+
+		BFS();
+		if(area < 2) {		// BFS가 끝났는데 area(빙산 구역)이 2개 미만이라면 다 녹을 떄까지 두 덩이 이상이 아님
+			sb.append("0");
+		} else {
+			sb.append(year);
+		}
+
+		br.close();
+		bw.write(sb.toString());
+		bw.flush();
+		bw.close();
+
+	}
+
+	private static void BFS() {
+		year = 0;
+		size = 0;
+
+		while(!q.isEmpty()) {
+			size = q.size();		// 1년 씩 빙산를 녹이기 위해 Queue size() 저장
+
+			areaCheck();		// 현재 빙산 구역 확인
+
+			if(area != 1) {		// 빙산이 다 녹았거나(area==0) 두 구역(area >= 2)일 때 전체 종료
+				break;
+			}
+			year += 1;		// 빙산이 남았고 한 구역이기 때문에 1년 증가
+
+			while(size-- > 0) {
+				int[] now = q.poll();
+
+				for(int k = 0; k < 4; k++) {
+					int nx = now[0] + dx[k];
+					int ny = now[1] + dy[k];
+
+					if(nx < 0 || ny < 0 || nx >= N || ny >= M) {
+						continue;
+					}
+
+					if(map[nx][ny] == 0) {		// 주변이 빙산이 아닌 바다라면
+						tmp[now[0]][now[1]] += 1;		// 빙산이 줄어들 크기를 1 증가
+					}
+
+				}
+			}
+
+			// 1년치 빙산이 줄어들 크기를 모두 계산한 후에, tmp를 다 돌면서 빙산 크기를 줄이기
+			for(int a = 0; a < N; a++) {
+				for(int b = 0; b < M; b++) {
+					if(tmp[a][b] != 0) {
+						// 빙산이 높이는 음수가 없기에 다 녹으면 0, 남아 있다면 해당 값으로 변경
+						map[a][b] = map[a][b] - tmp[a][b] < 0 ? 0 : map[a][b] - tmp[a][b];
+						tmp[a][b] = 0;		// 줄어들 빙산 크기 0으로 초기화
+					}
+					if(map[a][b] >= 1) {		// 녹은 후 빙산이 아직 남아 있다면 q에 다시 넣기
+						q.add(new int[] {a, b});
+					}
+				}
+			}
+
+
+		}
+	}
+
+	private static void areaCheck() {
+		visited = new boolean[N][M];		// 빙산 방문 초기화
+		area = 0;		// 구역 변수 초기화
+
+		for(int i = 0; i < N; i++) {
+			for(int j = 0; j < M; j++) {
+				if(!visited[i][j] && map[i][j] > 0) {		// 방문하지 않은 빙산이라면 또 다른 BFS로 구역 개수 탐색
+					BFS2(i, j);
+					area += 1;		// 한 번의 BFS가 끝날 때마다 구역 1 증가
+				}
+			}
+		}
+	}
+
+	private static void BFS2(int i, int j) {
+		Queue<int[]> q2 = new LinkedList<>();		// 빙산 구역을 나누기 위해 새로운 Queue
+		q2.add(new int[] {i, j});
+		visited[i][j] = true;		// 현재 빙산 방문 처리
+
+		while(!q2.isEmpty()) {
+			int[] now = q2.poll();
+
+			for(int k = 0; k < 4; k++) {
+				int nx = now[0] + dx[k];
+				int ny = now[1] + dy[k];
+
+				if(nx < 0 || ny < 0 || nx >= N || ny >= M || visited[nx][ny]) {
+					continue;
+				}
+
+				if(map[nx][ny] > 0) {
+					visited[nx][ny] = true;
+					q2.add(new int[] {nx, ny});
+				}
+			}
+		}
+	}
+
+}

--- a/youngtae/week1/Week1_4963.java
+++ b/youngtae/week1/Week1_4963.java
@@ -8,8 +8,8 @@ public class Week1_4963 {
 	static int W, H;
 	static int[] dx = {0, 1, 0, -1, 1, -1, -1, 1};  // 상하좌우 + 대각선
 	static int[] dy = {1, 0, -1, 0, 1, -1, 1, -1};
-	static boolean[][] visited;
 	static int[][] map;
+	static boolean[][] visited;
 
 	public static void main(String[] args) throws Exception {
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

--- a/youngtae/week1/Week1_7569.java
+++ b/youngtae/week1/Week1_7569.java
@@ -1,0 +1,102 @@
+package week1;
+
+import java.io.*;
+import java.util.*;
+
+public class Week1_7569 {
+
+	static int N, M, H, day, size;
+	static int[] dx = {0, 0, 0, 1, 0, -1};
+	static int[] dy = {0, 0, 1, 0, -1, 0};
+	static int[] dz = {1, -1, 0, 0, 0, 0};
+	static int[][][] boxs;
+	static int GREEN_TOMATO;
+	static boolean[][][] visited;
+	static Queue<int[]> q = new LinkedList<>();
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringBuilder sb = new StringBuilder();
+
+		GREEN_TOMATO = 0;  // 익지 않은 토마토
+
+		StringTokenizer str = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(str.nextToken());
+		M = Integer.parseInt(str.nextToken());
+		H = Integer.parseInt(str.nextToken());
+
+		boxs = new int[H][M][N];
+		visited = new boolean[H][M][N];
+
+		for(int i = 0; i < H; i++) {
+			for(int j = 0; j < M; j++) {
+				str = new StringTokenizer(br.readLine());
+				for(int k = 0; k < N; k++) {
+					int status = Integer.parseInt(str.nextToken());  // 토마토 상태
+					if(status == 1) { 	// 익은 토마토
+						q.add(new int[] {i, j, k});		// 첫 BFS 탐색될 수 있도록 Queue에 먼저 삽입
+						visited[i][j][k] = true;	// 다른 토마토에서 방문할 수 없도록 방문 처리
+					} else if(status == 0) {	// 익지 않은 토마토
+						GREEN_TOMATO += 1;		// 개수 체크
+					}
+
+					boxs[i][j][k] = status;
+				}
+			}
+		}
+
+		solution(sb);
+
+		br.close();
+		bw.write(sb.toString());
+		bw.flush();
+		bw.close();
+
+	}
+
+	private static void solution(StringBuilder sb) {
+		if(GREEN_TOMATO == 0) {		// 익지 않은 토마도가 하나도 없다면 BFS() 탐색 없이 바로 종료
+			sb.append("0");
+			return;
+		}
+
+		BFS();
+		sb.append(GREEN_TOMATO > 0 ? "-1" : day);		// 익지 않은 토마토가 1개 이상이라면 -1, 그렇지 않다면 소요일을 sb에 담기
+	}
+
+	private static void BFS() {
+		day = 0;		// 소요일 변수
+		size = 0;		// Queue 사이즈 담을 변수
+		while(!q.isEmpty()) {		// Queue가 빌 때까지 반복
+			size = q.size();		// BFS 탐색을 시작하기 전 현재 Queue size를 저장해 1일 치만 탐색 가능하도록 함.
+
+			while(size-- > 0) {		// 현 Queue size 만큼만 BFS 탐색
+				int[] now = q.poll();
+
+				for(int a = 0; a < 6; a++) {
+					int nz = now[0] + dz[a];
+					int nx = now[1] + dx[a];
+					int ny = now[2] + dy[a];
+
+					if(nz < 0 || nx < 0 || ny < 0 || nz >= H || nx >= M || ny >= N || visited[nz][nx][ny]) {
+						continue;
+					}
+
+					if(boxs[nz][nx][ny] == 0) {		// 익지 않은 토마토 발견
+						visited[nz][nx][ny] = true;
+						q.add(new int[] {nz, nx, ny});
+						GREEN_TOMATO -= 1;		// 익지 않은 토마토 총 개수에서 1개 차감
+					}
+				}
+			}
+
+			day += 1;		// 소요일 증가
+
+			if(GREEN_TOMATO <= 0) {		// 익지 않은 토마토가 다 익어졌다면 큐 종료
+				break;
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
## ✍️작성자
> 권영태

## 📝풀이 내용


> 4963(섬의 개수)
>> 섬의 경로를 찾은 것이 아닌, 모든 경로를 탐색해 총 섬의 개수를 파악하는 문제. 
하나의 섬에서 주변 섬을 탐색하는 방법으로 BFS로 풀이 선택.

> 7569(토마토)
>> 익은 토마토에서 주변(상하좌우)를 탐색하며 익지 않은 토마토를 하루마다 익도록 하는 문제.
입력 시 익은 토마토 위치를 기억(`Queue.add(익은 토마토 위치)`시키고, 이를 전염 전 익은 토마토 개수(`q.size()`)만큼 반복해 BFS()를 통해 토마토를 익게 한다.

> 2573(빙산)
>> 토마토 문제와 비슷하게 1년 마다 주변 바다 개수만큼 빙산을 녹여 빙산이 두 덩어리가 되는 해를 찾는 문제.
입력 시 빙산의 위치를 기억(`Queue.add(빙산 위치)`시키고, 이중 BFS()를 통해 빙산 덩어리 개수 확인 + 빙산 녹이기 조합으로 진행하면 된다.
**단, 빙산을 녹일 때 주변 바다 개수만큼 바로 녹이게 되면 바깥쪽 빙산이 먼저 녹아 안쪽 빙산이 녹게 되는 문제가 발생한다.**
그래서 빙산 녹일 값이 담겨진 배열`tmp[][]`를 통해 전체 빙산의 녹일 값을 계산 후 빙산을 한번에 녹여야 한다.


## 💬리뷰 요구사항(선택)
