### PR TITLE
[week1] 박기정

### DIFF
--- a/kijung/week1/Week1_2573.java
+++ b/kijung/week1/Week1_2573.java
@@ -1,0 +1,127 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Week1_2573 {
+
+    static int[][] map, dir = {{1, 0}, {-1, 0}, {0, 1}, {0, -1}};
+    static int row, col;
+    static Set<Pos> posSet = new HashSet<>();
+    static boolean[][] visited;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        row = Integer.parseInt(st.nextToken());
+        col = Integer.parseInt(st.nextToken());
+        map = new int[row][col];
+
+        for (int i = 0; i < row; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < col; j++) {
+                int height = Integer.parseInt(st.nextToken());
+                map[i][j] = height;
+                // 1.pos 리스트를 만들기
+                if (height != 0) {
+                    posSet.add(new Pos(i, j, height));
+                }
+            }
+        }
+
+        int year = 0;
+        while (true) {
+            if (posSet.isEmpty()) { // pos set이 비어있을 경우 0 출력
+                year = 0;
+                break;
+            }
+
+            // 2.pos 리스트에서 시작점을 통해 DFS를 통해 탐색한 좌표수와 pos 리스트 길이 비교. (다를 경우 두덩이 이상인 경우임)
+            Pos first = posSet.iterator().next();
+            if (dfs(first) != posSet.size()) {
+                break;
+            }
+
+            // 3.pos 리스트 탐색하면서 높이 바꿔줌(다 탐색후 0으로 바꿔줘야 함).
+            for (Pos pos : posSet) {
+                pos.height -= findZero(pos);
+            }
+
+            // 높이가 0이하가 되면 제거 및 맵에 반영
+            remove();
+
+            year++;
+        }
+
+        System.out.println(year);
+    }
+
+
+
+    // 상하좌우 0이 저장된 개수 반환.
+    static int findZero(Pos pos) {
+        int curRow = pos.row;
+        int curCol = pos.col;
+        int count = 0;
+
+        for (int[] d : dir) {
+            int nextRow = curRow + d[0];
+            int nextCol = curCol + d[1];
+            if (nextRow >= row || nextRow < 0 || nextCol >= col || nextCol < 0) continue;
+            if (map[nextRow][nextCol] == 0) count++;
+        }
+
+        return count;
+    }
+
+    // DFS
+    static int dfs(Pos pos) {
+        int count = 0;
+        visited = new boolean[row][col];
+        Stack<int[]> stack = new Stack<>();
+        visited[pos.row][pos.col] = true;
+        stack.push(new int[]{pos.row, pos.col});
+
+        while (!stack.isEmpty()) {
+            count++;
+            int curRow = stack.peek()[0];
+            int curCol = stack.peek()[1];
+            stack.pop();
+
+            for (int[] d : dir) {
+                int nextRow = curRow + d[0];
+                int nextCol = curCol + d[1];
+                if (nextRow >= row || nextRow < 0 || nextCol >= col || nextCol < 0) continue;
+                if (visited[nextRow][nextCol] || map[nextRow][nextCol] == 0) continue;
+                visited[nextRow][nextCol] = true;
+                stack.push(new int[]{nextRow, nextCol});
+            }
+        }
+
+        return count;
+    }
+
+    // 높이가 0이하가 되면 제거 및 맵에 반영
+    static void remove() {
+        Iterator<Pos> iterator = posSet.iterator();
+        while (iterator.hasNext()) {
+            Pos pos = iterator.next();
+            if (pos.height <= 0) {
+                map[pos.row][pos.col] = 0;
+                iterator.remove(); // 제거
+            }
+        }
+    }
+}
+
+
+class Pos {
+    int row;
+    int col;
+    int height;
+
+    public Pos(int row, int col, int height) {
+        this.row = row;
+        this.col = col;
+        this.height = height;
+    }
+}

--- a/kijung/week1/Week1_4963.java
+++ b/kijung/week1/Week1_4963.java
@@ -1,0 +1,74 @@
+import java.io.*;
+import java.util.*;
+
+public class BaekJoon_4963 {
+
+    static int row, col;
+    static int[][] map, dir = {{-1, 0}, {-1, 1}, {0, 1}, {1, 1}, {1, 0}, {1, -1}, {0, -1}, {-1, -1}}; // 방항배열
+    static boolean[][] visited;
+    static List<int[]> posList;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st;
+
+        while (true) {
+            st = new StringTokenizer(br.readLine());
+            col = Integer.parseInt(st.nextToken());
+            row = Integer.parseInt(st.nextToken());
+            if (row == 0 && col == 0) break;
+
+            map = new int[row][col];
+            visited = new boolean[row][col];
+            posList = new ArrayList<>(); // 섬 좌표 저장
+
+            for (int i = 0; i < row; i++) {
+                st = new StringTokenizer(br.readLine());
+                for (int j = 0; j < col; j++) {
+                    int value = Integer.parseInt(st.nextToken());
+                    map[i][j] = value;
+                    if (value > 0) posList.add(new int[]{i, j});
+                }
+            }
+
+            bw.write(find() + "\n");
+
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    static int find() {
+        int count = 0;
+        for (int[] pos : posList) {
+            int curR = pos[0];
+            int curC = pos[1];
+            if (visited[curR][curC]) continue; // 방문했던 좌표라면 생략
+            count++;
+            search(curR, curC);
+        }
+
+        return count;
+    }
+
+    static void search(int curR, int curC) { // bfs로 방문 처리
+        Queue<int[]> queue = new LinkedList<>();
+        visited[curR][curC] = true;
+        queue.add(new int[]{curR, curC});
+
+        while (!queue.isEmpty()) {
+            int[] pos = queue.poll();
+
+            for (int[] d : dir) {
+                int nextR = pos[0] + d[0]; // 다음 탐색할 곳
+                int nextC = pos[1] + d[1];
+                if (nextR >= row || nextR < 0 || nextC >= col || nextC < 0) continue;
+                if (visited[nextR][nextC] || map[nextR][nextC] == 0) continue;
+                visited[nextR][nextC] = true;
+                queue.add(new int[]{nextR, nextC});
+            }
+        }
+    }
+}

--- a/kijung/week1/Week1_7569.java
+++ b/kijung/week1/Week1_7569.java
@@ -1,0 +1,76 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class BaekJoon_7569 {
+    static int row, col, height, totalTomato, curTomato = 0;
+    static int[][][] map;
+    static int[][] dir = {{0, 0, 1}, {0, 0, -1}, {0, 1, 0}, {0, -1, 0}, {1, 0, 0}, {-1, 0, 0}};
+    static Queue<int[]> tomatoes = new LinkedList<>();
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        col = Integer.parseInt(st.nextToken());
+        row = Integer.parseInt(st.nextToken());
+        height = Integer.parseInt(st.nextToken());
+        map = new int[height][row][col];
+        totalTomato = row * col * height; // 총 토마토 개수
+
+        for (int i = 0; i < height; i++) {
+            for (int j = 0; j < row; j++) {
+                st = new StringTokenizer(br.readLine());
+                for (int k = 0; k < col; k++) {
+                    int value = Integer.parseInt(st.nextToken());
+                    map[i][j][k] = value;
+                    if (value == -1) totalTomato--;
+                    else if (value == 1) tomatoes.add(new int[]{i, j, k});
+                }
+            }
+        }
+
+        System.out.println(start());
+
+    }
+
+    static int start() {
+        int year = 0;
+
+        while (!tomatoes.isEmpty()) {
+            int size = tomatoes.size();
+            boolean isChanged = false;
+
+            for (int i = 0; i < size; i++) { // 큐에 있던 토마토 개수만큼 반복
+                int[] info = tomatoes.poll();
+                int curH = info[0];
+                int curR = info[1];
+                int curC = info[2];
+                curTomato++; // 익은 토마토 수 증가
+                for (int[] d : dir) {
+                    int nextH = curH + d[0];
+                    int nextR = curR + d[1];
+                    int nextC = curC + d[2];
+
+                    if (check(nextH, nextR, nextC)) {
+                        map[nextH][nextR][nextC] = 1;
+                        tomatoes.add(new int[]{nextH, nextR, nextC});
+                        isChanged = true;
+                    }
+                }
+
+            }
+
+
+            if (isChanged) year++;
+
+        }
+
+        if (totalTomato == curTomato) return year; // 총 익은 토마토 수와 전체 토마토 수 같으면 year 반환
+        else return -1;
+    }
+
+    static boolean check(int h, int r, int c) {
+        if (h >= height || h < 0 || r >= row || r < 0 || c >= col || c < 0) return false;
+        return map[h][r][c] == 0;
+    }
+}


### PR DESCRIPTION
## ✍️작성자

> 박기정

## 📝풀이 내용

> 2573 빙산

맵을 전부 다 탐색하기보다 빙산의 좌표들을 따로 저장하여 그 좌표들만 탐색하고자 하였습니다.

- Pos 객체를 저장하는 set을 탐색하며 set의 첫 좌표를 DFS로 탐색하였습니다.
첫 좌표만 사용해도 되는 이유는 두 덩이 이상으로 분리되는 것만 확인하면 되기 때문입니다.
한 덩이라면 첫 좌표로 탐색한 빙산의 좌표 수가 전체 빙산의 좌표수와 같아야 합니다. 다를 경우 두 덩이로 분리된 것입니다. 

- 만약 좌표수가 같다면 좌표들을 탐색하며 높이를 바꿔줍니다. 맵의 상하좌우를 탐색했을 때 나오는 0의 개수만큼 감소합니다.
높이를 다 바꿔준 이후 높이가 0 이하가 된다면 set에서 제거 후 맵에 반영하였습니다.


> 4963 섬의 개수

빙산과 마찬가지로 좌표들을 따로 저장하여 좌표들만 탐색하고자 하였습니다. 
다만 이번에는 class 대신 배열로 좌표를 저장하였습니다.

- visited 배열을 사용하여 좌표들의 중복 탐색을 방지하였습니다. 
만약 방문했던 좌표라면 생략하여 BFS를 생략, 방문하지 않았다면 개수를 증가시키며 BFS로 방문처리를 해주었습니다.

>7569 토마토

한번 영향을 미쳤던 토마토는 그 이후에는 다시 영향을 미치지 못하기 때문에 토마토의 좌표들을 별도로 저장하였습니다.
다만 날짜별로 익는 토마토는 다르기 때문에 BFS에 사용될 큐를 전역 변수로 사용하여 좌표들을 큐에 저장하였습니다.

- 첫 큐의 사이즈만큼만 BFS를 작동시키면 같은 날짜의 토마토만 큐에서 빠지게 됩니다. 
이를 적용시키지 않으면 다른 날짜의 토마토도 같이 익게 됩니다. 
만약 이것이 싫다면 별도의 클래스로 선언하여 토마토의 읽은 날짜를 함께 표현하면 될 것 같습니다.

- 토마토가 다 익었는지 확인하려면 삼중 포문을 도는 방법도 있지만 저는 다른 방법을 사용하였습니다. 토마토가 없는 칸을 제외한 전체 토마토의 수를 totalTomato에 저장하였고, 총 익은 토마토의 수가 전체 토마토의 수와 같은지 비교하였습니다.


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) BFS 내에서 시간 또는 메모리를 더 줄일 수 있을까요?
