### PR TITLE
[week3] 양여은

### DIFF
--- a/src/yeoeun/week03/Week3_1647.java
+++ b/src/yeoeun/week03/Week3_1647.java
@@ -1,0 +1,91 @@
+package yeoeun.week03;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Week3_1647 {
+    static int N, M;
+    static int[] root;
+    static HashMap<Integer, Integer> map = new HashMap<>(); // 그래프(루트) 별 총 노드 수
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        root = new int[N+1];
+        for (int i = 1; i <= N; i++) {
+            root[i] = i;
+            map.put(i, 1); // 모두 연결X 상태
+        }
+
+        // 모든 edge에 대해 cost가 낮은 순으로 정렬
+        PriorityQueue<Road> pq = new PriorityQueue<>(Comparator.comparing(r -> r.cost));
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int src = Integer.parseInt(st.nextToken());
+            int dst = Integer.parseInt(st.nextToken());
+            int cost = Integer.parseInt(st.nextToken());
+            pq.add(new Road(src, dst, cost));
+        }
+
+        int minTotalCost = 0;
+        while(!pq.isEmpty()) {
+            Road road = pq.poll();
+
+            int a = find(road.src);
+            int b = find(road.dst);
+
+            // 서로 다른 그래프에 연결된 경우
+            if(a != b) {
+                // 마을이 2개이고, 두 그래프의 노드 수의 합이 N과 같다면 분리 완료
+                if(map.size() == 2 && map.get(a) + map.get(b) == N) {
+                    break;
+                }
+
+                // 이외에는 병합 수행
+                union(a, b);
+                minTotalCost += road.cost;
+            }
+        }
+        System.out.println(minTotalCost);
+    }
+
+    private static void union(int a, int b) {
+        a = find(a);
+        b = find(b);
+
+        if(a != b) {
+            root[b] = a;
+
+            // 두 그래프를 합친 크기로 update, 나머지 하나는 삭제
+            map.replace(a, map.get(a) + map.get(b));
+            map.remove(b);
+        }
+    }
+
+    // root 정보를 찾아주는 메소드
+    private static int find(int node) {
+        if(root[node] == node) return node;
+        root[node] = find(root[node]);
+        return root[node];
+    }
+
+    public static class Road {
+        int src;
+        int dst;
+        int cost;
+
+        public Road(int src, int dst, int cost) {
+            this.src =src;
+            this.dst = dst;
+            this.cost = cost;
+        }
+    }
+}

--- a/src/yeoeun/week03/Week3_1717.java
+++ b/src/yeoeun/week03/Week3_1717.java
@@ -1,0 +1,56 @@
+package yeoeun.week03;
+
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class Week3_1717 {
+    static int[] root;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        root = new int[n+1];
+        for (int i = 1; i <= n; i++) {
+            root[i] = i;
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int command = Integer.parseInt(st.nextToken());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            if(command == 0) { // 합집합
+                union(a, b);
+            } else if (command == 1) { // 연결 여부 확인
+                a = find(a);
+                b = find(b);
+
+                // 루트가 같다면 연결된 상태
+                if(a == b) bw.write("YES\n");
+                else bw.write("NO\n");
+            }
+        }
+        bw.flush();
+        br.close();
+        bw.close();
+    }
+
+    private static void union(int a, int b) {
+        a = find(a);
+        b = find(b);
+
+        if(a != b) root[b] = a;
+    }
+
+    private static int find(int node) {
+        if(root[node] == node) return node;
+
+        root[node] = find(root[node]);
+        return root[node];
+    }
+}

--- a/src/yeoeun/week03/Week3_24542.java
+++ b/src/yeoeun/week03/Week3_24542.java
@@ -1,0 +1,69 @@
+package yeoeun.week03;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.StringTokenizer;
+
+public class Week3_24542 {
+    static int[] root; // 부모(루트) 정보를 관리
+    static HashMap<Integer, Integer> map = new HashMap<>(); // 그래프 별 노드 개수 관리 (root 기준)
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        root = new int[N+1];
+        for (int i = 1; i <= N; i++) {
+            root[i] = i; // 초기 설정 : 루트를 자기 자신으로 초기화
+        }
+
+        for (int i = 0; i < M; i++) {
+            // 연결 정보 받아오기
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            // a - b 연결 시 변화 계산
+            union(a, b);
+        }
+
+        long answer = 1;
+        for (Integer cnt : map.values()) {
+            // 각 그룹별 1명씩 주면 됨 -> 그래프 별 경우의 수 == 노드 수
+            // 총 경우의 수 == 그래프 별 노드 수를 모두 곱한 값
+            answer = (answer * cnt) % 1000000007;
+        }
+        System.out.println(answer);
+    }
+
+    private static void union(int a, int b) {
+        // 각각의 루트노드 값으로 갱신
+        a = find(a);
+        b = find(b);
+
+        if(a != b) { // 서로 다른 그래프에 속해 있는 경우
+            root[b] = a; // 연결 정보 업데이트
+
+            // 경우의 수를 줄이기 위해 map에 항상 a, b가 있도록 설정
+            if(!map.containsKey(a)) map.put(a, 1);
+            if(!map.containsKey(b)) map.put(b, 1);
+
+            // 노드의 수 계산 (합치기)
+            map.replace(a, map.get(a) + map.get(b));
+            map.remove(b);
+        }
+    }
+
+    private static int find(int node) {
+        if(root[node] == node) { // 자신이 루트인 경우
+            return node;
+        } else { // 재귀로 root 노드 탐색
+            root[node] = find(root[node]); // 재탐색 시 시간 단축용
+            return root[node];
+        }
+    }
+}


### PR DESCRIPTION
## ✍️작성자

> 양여은

## 📝풀이 내용

> 1647: 도시 분할 계획
- 간선 정보를 cost 순으로 관리하는 PriorityQueue와, 각 루트(그래프)별 총 노드 수를 관리하는 Map을 사용하였습니다.
- cost가 낮은 간선부터 가져와, 해당 간선의 양 끝 노드가 연결되어 있지 않은 상태라면 이를 연결하는 작업을 반복함으로써 MST를 구성하였습니다.
- 마을이 2개이고, 두 그래프의 노드 수의 합이 N과 같다면 분리 완료이므로 나머지 edge를 계산하지 않고 계산을 종료합니다.

> 1717: 집합의 표현
- command가 0인 경우에는 두 그래프를 합치는 union()을 실행
- command가 1인 경우에는 각각의 루트를 find()를 통해 찾아 비교

> 24542: 튜터-튜티 관계의 수
- 각 루트(그래프)별 총 노드 수를 관리하는 Map을 사용하였습니다.
- 엣지에 대해 연결 연산을 모두 수행한 후, 최종적으로 Map에 남아 있는 values 값들을 모두 곱해 경우의 수를 도출하였습니다.

## 💬리뷰 요구사항(선택)
