### PR TITLE
[week5] 황지연 

### DIFF
--- a/src/jiyeon/week5/boj_10330.java
+++ b/src/jiyeon/week5/boj_10330.java
@@ -1,0 +1,164 @@
+package week5;
+
+import java.util.*;
+import java.io.*;
+
+public class boj_10330 {
+	
+	static int N,M; 
+	static int [] bits ; //비트문자열
+	static int [] codes; //연속 코드 
+	static int [][] candidates = new int[2][]; //바꿔야 하는 문자열의 후보를 저장하는 배열 
+	static int min = Integer.MAX_VALUE;
+	
+	/*
+	 * 1. 연속 코드가 같은 문자열 후보 두 가지 먼저 만들어 놓기 o
+	 * 2. 각 각의 최솟값 구하고 더 작은 값 출력 
+	 * 
+	 * */
+	
+
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		bits = new int[N];
+		codes = new int[M];
+		candidates = new int[2][N];
+		
+		st = new StringTokenizer(br.readLine());
+		for(int i=0; i<N; i++) {
+			bits[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		st = new StringTokenizer(br.readLine());
+		for(int i=0; i<M; i++) {
+			codes[i] = Integer.parseInt(st.nextToken());
+		}
+		// 입력 
+
+		candidates[0] = makeCandidate(candidates[0], 0);
+		candidates[1] = makeCandidate(candidates[1], 1);
+		
+		int input0Num = get0Num(bits);
+		
+		for(int a = 0; a<2; a++) {
+			int [] candi = candidates[a];
+			int count = 0;
+			
+			//연산을 통해 재배열이 가능한지 여부 파악 
+			int candi0Num = get0Num(candi);
+			
+			if(candi0Num!=input0Num){
+				continue;
+			}
+			
+			int [] copyBits = copyArr(bits);
+			
+			for(int i=0; i<N; i++) {
+				if(candi[i] == copyBits[i])
+					continue;
+				
+				int changeIndex = findIndex(i,copyBits);
+				count += (changeIndex - i);
+				swap(i,changeIndex,copyBits);
+			}
+			
+			min = Math.min(min, count);
+		} //for 
+		
+		System.out.println(min);
+		
+		
+		
+	}//main
+	
+	
+	
+	//배열 copy 메서드
+	static int[] copyArr(int[] bits){
+		int [] copy = new int[N];
+		for(int i=0; i<N; i++)
+			copy[i] = bits[i];
+		
+		return copy;
+	}
+	
+	//후보 만드는 메서드 (0으로 시작하는 문자열, 1로 시작하는 문자열)
+	static int[] makeCandidate(int[] arr, int startNum) {
+		int start = 0;
+		int end = codes[0];
+		int num = startNum;
+		
+		for(int i=1; i<=M; i++) {
+			
+			for(int j=start; j<end; j++) {
+				arr[j] = num;
+			}
+			
+			if(i==M)
+				break;
+			
+			start += codes[i-1];
+			end += codes[i];
+			
+			if(num == 0)
+				num = 1;
+			else 
+				num = 0;
+		}
+		
+		
+		return arr;
+		
+	}//makeCandidate
+	
+	
+	//자기 자신의 인덱스를 기준으로 바꿔야하는 값을 가진 가장 가까운 인덱스가 어디에 있는지 찾는 메서드
+	static int findIndex(int ownIndex, int [] arr ) {
+		int num = arr[ownIndex];
+		int findNum = 0;
+		if (num == 0)
+			findNum = 1;
+		
+		int index = 0;
+		for(int i=ownIndex+1; i<N; i++) {
+			if(arr[i] == findNum) {
+				index = i;
+				break;
+			}
+		}
+		
+		return index;
+		
+	}//findIndex
+	
+	
+	//swap 메서드 
+	static void swap (int ownIndex, int findIndex,int[] arr ) {
+		
+		int temp = arr[ownIndex];
+		arr[ownIndex] = arr[findIndex];
+		arr[findIndex] =temp;
+		
+	}//swap
+	
+	//문자열에 있는 0의 개수 카운트
+	static int get0Num(int [] arr) {
+		int count = 0;
+		
+		for(int i=0; i<N; i++) {
+			if(arr[i]==0)
+				count ++;
+		}
+		
+		return count;
+	}
+	
+
+	
+
+}

--- a/src/jiyeon/week5/boj_11000.java
+++ b/src/jiyeon/week5/boj_11000.java
@@ -1,0 +1,55 @@
+package week5;
+
+import java.util.*;
+import java.io.*;
+
+
+public class boj_11000 {
+	
+	static int N,count;
+	static int[][] input;
+	static PriorityQueue<Integer> pq = new PriorityQueue<>(); //강의실 별 수업이 끝나는 시간 저장 
+	public static void main(String[] args) throws IOException{
+		
+		BufferedReader br = new BufferedReader (new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		input = new int[N][2];
+		
+		for(int i=0; i<N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			input[i][0] = Integer.parseInt(st.nextToken());
+			input[i][1] = Integer.parseInt(st.nextToken());
+		} //입력 
+		
+		Arrays.sort(input, new Comparator<int []>() {
+			
+			@Override
+			public int compare (int[] o1, int[] o2) {
+				
+				if(o1[0]==o2[0])
+					return o1[1]-o2[1];
+				
+				return o1[0]-o2[0];
+			}
+		}); //sort
+		
+		pq.add(input[0][1]);
+		
+		for(int i=1; i<N; i++) {
+			
+			int curEnd = pq.peek(); //제일 먼저 끝나는 시간 확인 
+			
+			if(curEnd<=input[i][0]) { //제일 먼저 끝나는 시간이 현재 수업의 시작하는 시간보다 빠르면 큐에서 빼내기 
+				pq.poll(); 
+			}
+
+			pq.add(input[i][1]);
+
+			
+		}
+		
+		System.out.println(pq.size()); 
+
+	}
+
+}

--- a/src/jiyeon/week5/boj_15903.java
+++ b/src/jiyeon/week5/boj_15903.java
@@ -1,0 +1,47 @@
+package week5;
+
+import java.util.*;
+import java.io.*;
+
+
+public class boj_15903 {
+
+	static PriorityQueue<Long> pq = new PriorityQueue<>(); //카드를 합치면서 int범위를 벗어날 수 있으므로 Long으로 선언
+	static int n,m;
+	
+	public static void main(String[] args) throws IOException{
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		n = Integer.parseInt(st.nextToken());
+		m = Integer.parseInt(st.nextToken());
+		
+		st = new StringTokenizer(br.readLine());
+		
+		for(int i=0; i<n; i++) {
+			pq.add((long) Integer.parseInt(st.nextToken()));
+		}
+		
+		for(int i=0; i<m; i++) {
+			
+			long n1 = pq.poll();
+			long n2 = pq.poll();
+			
+			long sum = n1+n2;
+			
+			pq.add(sum);
+			pq.add(sum);
+		}
+		
+		long total = 0;
+		
+		for(long num : pq)
+			total += num;
+		
+		System.out.println(total);
+
+		
+	}
+
+}


### PR DESCRIPTION
## ✍️작성자

> 황지연

## 📝풀이 내용

> **10330번 비트문자열 재배열하기**
>
> 비트 문자열을 재 배열하기 위해서는 초기 문자열의 0과 1의 개수와 나중 문자열의 개수가 같아야 한다. 
>따라서 무의미한 탐색을 방지하기 위하여 0의 개수를 카운트하고, 초기 문자열과 나중 문자열의 개수를 비교하였다. 같지 않다면 나중 문자열으로 만들 수 없으므로 continue; 해주었다. 
>문제에서 주어진 유일한 연산은 인접한 두 비트를 바꾸는 거지만, 여러 번 swap을 하기 번거로워서 한 번에 swap을 해주고, swap 대상 문자의 거리를 카운트 해주었다. 
>swap 대상을 지정할 때는 자신과 **가장 가까운** 대상 문자를 지정하였고, 첫 번째 문자열부터 차례대로 진행하였다.
>
>**11000번 강의실 배정**
>
> 강의 시작시간이 빠른 순으로 정렬, 만약 시작 시간이 같다면 종료 시간이 빠른 순으로 정렬하였다. 이후 입력받은 강의를 순차적으로 순회하며 강의 종료시간을 priortiy queue (pq)에 입력하였다. 
> pq의 첫 번째 종료시간(가장 빠른 종료시간)와 강의 시작 시간을 비교하여,  종료시간이 시작시간보다 빠르면 큐에서 빼내고, 아니라면 해당 강의의 종료 시간을 pq에 넣어주었다. 
> 모두 반복 한 후, pq의 size를 출력하였다. 
>
>**15903번 카드 합체 놀이** 
>
>이 문제의 핵심은 카드 합체 후 점수를 가장 작게 만드는 것이다. 이를 위해서는 카드의 값이 작은 것끼리 합체를 시켜줘야한다. 
> 따라서 Priority Queue를 통해 카드 점수가 작은 순 대로 정렬하였다. 
> PQ를 정의할 때 주의할 점은, 카드 점수의 범위로 인해 integer로 선언하면 안된다.. 따라서 LONG으로 선언하였다...
>이후 pq에서 카드를 두 개 빼고, 둘을 더한 값을 다시  pq에 두 번 넣어주면 된다. 이를 m번 반복하면 끝

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) BFS 내에서 시간 또는 메모리를 더 줄일 수 있을까요?
