### PR TITLE
[week5] 김희진

### DIFF
--- a/src/heejin/week5/Week5_10330.java
+++ b/src/heejin/week5/Week5_10330.java
@@ -1,0 +1,72 @@
+package heejin.week5;
+
+import java.io.*;
+import java.util.*;
+
+public class Week5_10330 {
+
+    static int N, M;
+    static int[] arr;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        arr = new int[N];
+
+        // 입력
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[] ans0 = new int[N]; // 0으로 시작하는 정답 비트 문자열
+        int[] ans1 = new int[N]; // 1로 시작하는 정답 비트 문자열
+        st = new StringTokenizer(br.readLine());
+
+        // 정답 비트 문자열 만들기
+        int idx = 0;
+        for (int i = 0; i < M; i++) {
+            int cnt = Integer.parseInt(st.nextToken());
+
+            int value0 = i % 2;
+            int value1 = (i + 1) % 2;
+
+            for (int j = 0; j < cnt; j++) {
+                ans0[idx] = value0;
+                ans1[idx++] = value1;
+            }
+        }
+
+        // 최소 연산 수 계산
+        int minCnt0 = calMinCnt(arr.clone(), ans0);
+        int minCnt1 = calMinCnt(arr.clone(), ans1);
+
+        System.out.print(Math.min(minCnt0, minCnt1));
+    }
+
+    static int calMinCnt(int[] arr, int[] ans) { // arr: 초기 문자열, ans: 정답 문자열
+        int cnt = 0;
+
+        for (int start = 0; start < ans.length; start++) {
+            if (arr[start] == ans[start]) { // 정답과 일치하면 다음 비트 문자 비교
+                continue;
+            }
+
+            int end = start;
+            while (end < N && arr[end] != ans[start]) { // 원하는 비트를 찾을 때까지 인접한 두 비트 스왑
+                cnt++; // 스왑 연산 카운트
+                end++;
+            }
+
+            if (end != N) {
+                arr[end] = (ans[start] + 1) % 2; // 최종 스왑 완료된 시점의 비트 값 바꾸기
+            } else {
+                return Integer.MAX_VALUE; // 정답 비트 문자열로 만들 수 없는 경우
+            }
+        }
+        return cnt;
+    }
+}

--- a/src/heejin/week5/Week5_11000.java
+++ b/src/heejin/week5/Week5_11000.java
@@ -1,0 +1,40 @@
+package heejin.week5;
+
+import java.io.*;
+import java.util.*;
+
+public class Week5_11000 {
+
+    static int N;
+    static int[][] time;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+        time = new int[N][2];
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            time[i][0] = Integer.parseInt(st.nextToken());
+            time[i][1] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(time, (t1, t2) -> {
+            if (t1[0] == t2[0]) {
+                return t1[1] - t2[1]; // 시작 시간 같으면 종료 시간 빠른 게 먼저
+            }
+            return t1[0] - t2[0]; // 시작 시간 빠른 게 먼저
+        });
+
+        PriorityQueue<Integer> pq = new PriorityQueue<>(); // 종료 시간 빠른게 앞에 오게
+        for (int i = 0; i < N; i++) {
+            if (!pq.isEmpty() && pq.peek() <= time[i][0]) { // 종료 시간 가장 빠른 것과 같은 강의실 가능
+                pq.poll();
+            }
+            pq.add(time[i][1]);
+        }
+
+        System.out.println(pq.size());
+    }
+}
+

--- a/src/heejin/week5/Week5_15903.java
+++ b/src/heejin/week5/Week5_15903.java
@@ -1,0 +1,37 @@
+package heejin.week5;
+
+import java.io.*;
+import java.util.*;
+
+public class Week5_15903 {
+    static int N, M;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        PriorityQueue<Long> pq = new PriorityQueue<>();
+
+        // 입력
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            pq.offer(Long.parseLong(st.nextToken()));
+        }
+
+        // 가장 작은 값 두 개를 매번 더하기
+        for (int i = 0; i < M; i++) {
+            long sum = pq.poll() + pq.poll();
+            pq.offer(sum);
+            pq.offer(sum);
+        }
+
+        // 점수 계산
+        long score = 0;
+        while (!pq.isEmpty()) {
+            score += pq.poll();
+        }
+        System.out.print(score);
+    }
+}


### PR DESCRIPTION
## ✍️작성자

> 김희진

## 📝풀이 내용

> 15903 카드 합체 놀이

- 연속적으로 더한 값이 최소가 되어야하므로, 가장 작은 값부터 더해야 함
- 우선순위 큐를 이용해 입력을 받아, 작은 값이 우선순위가 높도록 저장
- 우선순위 큐에서 값을 두 개씩 꺼내가며 M번 덧셈 수행
- 모든 카드 값 더하여 점수 계산
(Long 타입 안 해서 계속 틀린 악몽의 문제..)

> 11000 강의실 배정

- 시작 시간이 빠른 순으로 정렬 (같으면 종료 시간 빠른순)
- 앞서 정렬한 리스트에서 첫 원소의 종료 시간만 우선순위 큐에 삽입(종료 시간이 빠른 순)
- 큐에는 각 강의실별 마지막 강의 종료 시간이 들어가 있음
- (아직 강의실이 결정 되지 않은 강의들 중 시작 시간이 가장 빠른 강의)를 (강의실이 결정된 강의들 중 종료 시간이 가장 빠른 강의)와 동일한 강의실에 넣는 게 최선의 선택

> 10330 비트 문자열 재배열하기

- 정답 배열은 0으로 시작하거나 1로 시작하거나 두 경우 밖에 없으므로 두 가지의 정답 배열 생성
- 정답 배열과 기존 배열의 원소를 하나씩 비교하며 최소 연산 수 계산
  - 만약 원소가 일치하지 않으면 기존 배열에서 일치하는 값을 찾을 때까지 뒤로 이동
    - ex. 기존 배열 0, 정답 배열 1 불일치 발생 -> 기존 배열에서 1을 찾을 때까지 다음 인덱스로 이동
  - 원하는 값을 찾으면 해당 값을 변경(스왑 의미)
    - ex. 기존 배열에서 1을 찾으면, 해당 값은 0으로 변경 
  - 만약 원하는 값을 찾지 못했으면, 정답 배열을 만들 수 없음을 의미
- 0으로 시작 or 1로 시작 정답 배열 중 더 작은 연산 값을 출력

## 💬리뷰 요구사항(선택)