### PR TITLE
[week5] 이진우

### DIFF
--- a/src/jinu/week5/Week5_10330.java
+++ b/src/jinu/week5/Week5_10330.java
@@ -1,0 +1,139 @@
+package jinu.week5;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Week5_10330 {
+
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+
+        //초기 배열
+        int inital[] = new int[N];
+        st = new StringTokenizer(br.readLine());
+
+        for(int i=0;i<N;i++){
+            inital[i] = Integer.parseInt(st.nextToken());
+        }
+
+
+        //처음에 0의 원소로 시작한다고 가정하고 출발한 배열 brr
+        int brr[] = new int[N];
+
+        //처음에 1의 원소로 시작한다고 가정하고 출발한 배열 crr
+        int crr[] = new int[N];
+
+
+        // 배열 초기화
+        int p = 0;
+        boolean zero = true;
+        st = new StringTokenizer(br.readLine());
+        for(int i=0;i<M;i++){
+            int k = Integer.parseInt(st.nextToken());
+
+            for(int j=0;j<k;j++){
+                if(zero){
+                    brr[p] = 0;
+                    crr[p] = 1;
+                }
+                else{
+                    brr[p] = 1;
+                    crr[p] = 0;
+                }
+                p++;
+            }
+            zero=!zero;
+        }
+
+
+        // 배열 brr 에서 i=0 부터 순서대로 원소의 종류를 initial 과 비교하며
+        // 다른 경우 그 원소를 가지고 있는 i보다 크고 가까운 index 를 찾아 움직이고 비용 계산
+
+        int sum1 = 0;
+        for(int i=0;i<N;i++){
+            if(brr[i] == inital[i]){
+                continue;
+            }
+
+            int nearIndex = getNearIndex(i,brr,inital);
+
+            //-1 인 경우 원소의 종류가 같고 가까운 index 를 못찾음.
+            if(nearIndex == -1){
+                sum1 = -1;
+                break;
+            }
+
+            sum1+=(nearIndex-i);
+            move(brr,nearIndex,i);
+        }
+
+        // 배열 crr 에서 i=0 부터 순서대로 원소의 종류를 initial 과 비교하며
+        // 다른 경우 그 원소를 가지고 있는 i보다 크고 가까운 index 를 찾아 움직이고 비용 계산
+        int sum2 = 0;
+        for(int i=0;i<N;i++){
+            if(crr[i] == inital[i]){
+                continue;
+            }
+
+            int nearIndex = getNearIndex(i,crr,inital);
+
+            if(nearIndex == -1){
+                sum2 = -1;
+                break;
+            }
+
+            sum2+=(nearIndex-i);
+            move(crr,nearIndex,i);
+        }
+
+        System.out.println(getAnswer(sum1,sum2));
+
+
+
+    }
+
+    public static int getNearIndex(int i,int brr[],int initial[]){
+        for(int k=i+1;k<brr.length;k++){
+            if(initial[i]==brr[k]){
+                return k;
+            }
+        }
+
+        return -1;
+    }
+
+    public static void move(int brr[],int findIndex,int i){
+        for(int k=findIndex;k>i;k--){
+            swap(brr,k,k-1);
+        }
+    }
+
+    public static void swap(int brr[],int i,int j){
+        int tmp = brr[i];
+        brr[i] = brr[j];
+        brr[j]= tmp;
+    }
+
+    public static void print(int crr[]){
+        for(int i=0;i<crr.length;i++){
+            System.out.print(crr[i]+" ");
+        }
+        System.out.println();
+    }
+
+    //정답 출력
+    public static int getAnswer(int sum1,int sum2){
+        if(sum1 ==-1 || sum2 ==-1){
+            return sum1==-1?sum2:sum1;
+        }
+
+        return Math.min(sum1,sum2);
+    }
+}

--- a/src/jinu/week5/Week5_11000.java
+++ b/src/jinu/week5/Week5_11000.java
@@ -1,0 +1,78 @@
+package jinu.week5;
+
+import com.sun.security.jgss.GSSUtil;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.sql.Time;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+
+public class Week5_11000 {
+
+    static class TimeTable implements Comparable<TimeTable>{
+
+        int start;
+        int end;
+
+        public TimeTable(int start,int end){
+            this.start = start;
+            this.end = end;
+        }
+
+        @Override
+        public int compareTo(TimeTable o){
+            return end - o.end;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        List<TimeTable> timeTables = new ArrayList<>();
+
+        for(int i=0;i<N;i++){
+            st = new StringTokenizer(br.readLine());
+            timeTables.add(new TimeTable(Integer.parseInt(st.nextToken()),Integer.parseInt(st.nextToken())));
+        }
+
+        Collections.sort(timeTables,(o1,o2)-> {
+            if(o1.start==o2.start){
+                return o2.end-o1.end;
+            }
+
+            return o1.start-o2.start;
+        });
+
+
+        PriorityQueue<Integer> pq = new PriorityQueue<>();
+        pq.add(timeTables.get(0).end);
+
+        for(int i=1;i<N;i++){
+
+            if(pq.peek()<=timeTables.get(i).start){
+                pq.poll();
+            }
+            pq.add(timeTables.get(i).end);
+        }
+
+        System.out.println(pq.size());
+
+
+
+
+
+
+
+
+
+
+    }
+
+}

--- a/src/jinu/week5/Week5_15903.java
+++ b/src/jinu/week5/Week5_15903.java
@@ -1,0 +1,44 @@
+package jinu.week5;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Week5_15903 {
+
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        //pq 에서 작은 것 부터 2개 꺼내어 다시 pq 에 저장
+        PriorityQueue<Long> pq = new PriorityQueue<>();
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+
+        st = new StringTokenizer(br.readLine());
+        for(int i=0;i<n;i++){
+            pq.add(Long.parseLong(st.nextToken()));
+        }
+
+
+        for(int i=0;i<m;i++){
+            long first = pq.poll();
+            long second = pq.poll();
+
+            pq.add(first+second);
+            pq.add(first+second);
+        }
+
+
+        long sum = 0 ;
+        while(!pq.isEmpty()){
+            sum += pq.poll();
+        }
+
+        System.out.println(sum);
+    }
+    }
+}

--- a/src/jinu/week5/Week5_15903.java
+++ b/src/jinu/week5/Week5_15903.java
@@ -40,5 +40,5 @@ public class Week5_15903 {
 
         System.out.println(sum);
     }
-    }
+
 }


### PR DESCRIPTION
## ✍️작성자

> ex) 이진우

## 📝풀이 내용

> 문제 번호 + 풀이 내용 형식으로 작성해주세요.

### 15903 

문제에서 주어진 조건 그대로 가장 작은 2개를 ```priority_queue``` 의 poll 로 꺼내어 
그 합을 두 번 저장하는 방식으로 문제를 풀이하였습니다.


### 11000

어려워서 정답 코드를 참조하였습니다. 
먼저 시작 시간 기준으로 정렬하고 PriorityQueue 는 종료 시간 기준으로 만들어서 

지속적으로 PriorityQueue 의 최상단의 값(종료 시간이 가장 작은것) 과 시작 시간을 비교하여 만약 시작 시간이 더 같거나 크다면 
PriorityQueue 에서 해제하고 지속적으로 pq에 종료시간을 추가하여 

추후 PriorityQueue에 남아있는 원소의 개수가 최소 회의실이라는 점을 이용하였습니다.

다시 풀어도 명확하게 척척 진행하지 못할 것 같은 문제입니다.

### 10330

기존 배열과 임시 배열을  차례로 비교하여 같은 인덱스(i)의 원소가 달라지는 시점이 나온다면 
그 값을 i보다 큰 인덱스에서 swap 하면서 가지고 오는 그림으로 문제를 풀었습니다. 

하지만 이 문제에서 조차 확신이 많이 없었습니다. 


## 💬리뷰 요구사항(선택)

그리디 문제가 
정답 코드 및 해설을 보아도 흠 그런가? 하는 생각이 자꾸 듭니다 .

10330 과 11000 이런 문제들도 리뷰어님은 논리적으로 한 발자국 씩 접근하셨나요?
생각의 흐름이 궁금합니다. 


