### PR TITLE
[week5] 권영태

### DIFF
--- a/src/youngtae/week5/Week5_10330.java
+++ b/src/youngtae/week5/Week5_10330.java
@@ -1,0 +1,118 @@
+package youngtae.week5;
+
+import java.io.*;
+import java.util.*;
+
+public class Week5_10330 {
+
+	static int N, M, one, zero, result;
+	static int[] arr, tmp, ost, zst;
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringBuilder sb = new StringBuilder();
+		StringTokenizer str;
+
+		str = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(str.nextToken());
+		M = Integer.parseInt(str.nextToken());
+
+		arr = new int[N];
+		str = new StringTokenizer(br.readLine());
+		for(int i = 0; i < N; i++) {
+			int num = Integer.parseInt(str.nextToken());
+			if(num == 1) {
+				one += 1;
+			} else {
+				zero += 1;
+			}
+			arr[i] = num;
+		}
+
+		tmp = new int[M];
+		str = new StringTokenizer(br.readLine());
+		for(int i = 0; i < M; i++) {
+			tmp[i] = Integer.parseInt(str.nextToken());
+		}
+
+		ost = new int[N];
+		zst = new int[N];
+
+		// 0 또는 1로 시작하는 경우의 수 배열 만들기
+		init(ost, true);
+		init(zst, false);
+
+		result = Integer.MAX_VALUE;
+		if(count(ost)) {  // 0과 1의 개수가 실제 배열 개수와 일치하는지 확인
+			// 개수가 일치한다면 직접 이동시키면서 최소 이동 값 확인
+			result = Math.min(result, move(ost));
+		}
+		if(count(zst)) {
+			// 이동시키기
+			result = Math.min(result, move(zst));
+		}
+		sb.append(result);
+
+		bw.write(sb.toString());
+		bw.flush();
+		br.close();
+		bw.close();
+	}
+
+	private static int move(int[] arr2) {
+		int count = 0;
+		for(int i = 0; i < N; i++) {
+			if(arr2[i] != arr[i]) {
+				for(int j = i+1; j < N; j++) {
+					if(arr2[i] != arr2[j] && arr2[j] != arr[j]) {
+						int tmp = arr2[j];
+						arr2[j] = arr2[i];
+						arr2[i] = tmp;
+						count += j - i;
+						break;
+					}
+				}
+			}
+		}
+		return count;
+	}
+
+	private static boolean count(int[] arr) {
+		int arrOne = 0;
+		int arrZero = 0;
+		for(int i = 0; i < arr.length; i++) {
+			if(arr[i] == 1) {
+				arrOne += 1;
+				continue;
+			}
+
+			arrZero += 1;
+		}
+
+
+		return one == arrOne && zero == arrZero;
+	}
+
+	private static void init(int[] arr, boolean b) {
+		int count = 0;
+		int tIndex = 0;
+		int tNum = tmp[tIndex];
+		boolean flag = b;
+		for(int i = 0; i < N; i++) {
+			if(flag) {
+				arr[i] = 1;
+			} else {
+				arr[i] = 0;
+			}
+
+			count ++;
+
+			if(count == tNum && tIndex < M-1) {
+				count = 0;
+				tNum = tmp[++tIndex];
+				flag = !flag;
+			}
+		}
+	}
+}

--- a/src/youngtae/week5/Week5_11000.java
+++ b/src/youngtae/week5/Week5_11000.java
@@ -1,0 +1,64 @@
+package youngtae.week5;
+
+import java.io.*;
+import java.util.*;
+
+public class Week5_11000 {
+
+	static int N, result;
+	static int[][] arr;
+	static int[] ed;
+	static boolean[] isUsed;
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringBuilder sb = new StringBuilder();
+		StringTokenizer str;
+
+		N = Integer.parseInt(br.readLine());
+		arr = new int[N][2];
+		ed = new int[N];
+		isUsed = new boolean[N];
+		result = 0;
+
+		for(int i = 0; i < N; i++) {
+			str = new StringTokenizer(br.readLine());
+			int u = Integer.parseInt(str.nextToken());
+			int v = Integer.parseInt(str.nextToken());
+
+			arr[i][0] = u;
+			arr[i][1] = v;
+		}
+
+		Arrays.sort(arr, new Comparator<int[]>() {
+			@Override
+			public int compare(int[] o1, int[] o2) {
+				if(o1[0] == o2[0]) {
+					return o1[1] - o2[1];
+				}
+				return o1[0] - o2[0];
+			}
+		});
+
+		PriorityQueue<Integer> pq = new PriorityQueue<>();
+
+		for (int i = 0; i < N; i++) {
+			// 시작 시간이 pq(종료시간)보다 크다면 이어서 가능하다는 뜻.
+			if (!pq.isEmpty() && pq.peek() <= arr[i][0]) {
+				// 기존 강의실 배정을 제거하고
+				pq.poll();
+			}
+			// 새로운 타임으로 대체 || 새로운 강의실 배정
+			pq.offer(arr[i][1]);
+		}
+
+		sb.append(pq.size());
+
+		bw.write(sb.toString());
+		bw.flush();
+		br.close();
+		bw.close();
+	}
+
+}

--- a/src/youngtae/week5/Week5_11000_Wrong.java
+++ b/src/youngtae/week5/Week5_11000_Wrong.java
@@ -1,0 +1,77 @@
+package youngtae.week5;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * union-find로 시도한 방법
+ * 메모리 초과로 인한 실패 코드
+ */
+public class Week5_11000_Wrong {
+
+	static int N;
+	static int[] arr, result;
+	static HashMap<Integer, Integer> map = new HashMap<>();
+	static Set<Integer> set = new HashSet<>();
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringBuilder sb = new StringBuilder();
+		StringTokenizer str;
+
+		N = Integer.parseInt(br.readLine());
+		arr = new int[1000000000];
+		Arrays.fill(arr, -1);
+
+		for(int i = 0; i < N; i++) {
+			str = new StringTokenizer(br.readLine());
+			int u = Integer.parseInt(str.nextToken());
+			int v = Integer.parseInt(str.nextToken());
+
+			union(u, v);
+			map.put(u, 0);
+			map.put(v, 0);
+		}
+
+		for(int keys : map.keySet()) {
+			set.add(find(keys));
+		}
+
+		sb.append(set.size());
+		bw.write(sb.toString());
+		bw.flush();
+		br.close();
+		bw.close();
+	}
+
+	private static int find(int u) {
+		if(arr[u] < 0) {
+			return u;
+		}
+
+		return arr[u] = find(arr[u]);
+	}
+
+	private static void union(int u, int v) {
+		u = find(u);
+		v = find(v);
+
+		if(u == v) {
+			return;
+		}
+
+		if(arr[v] < arr[u]) {
+			int tmp = u;
+			u = v;
+			v = tmp;
+		}
+
+		if(arr[u] == arr[v]) {
+			arr[u]--;
+		}
+
+		arr[v] = u;
+	}
+
+}

--- a/src/youngtae/week5/Week5_15903.java
+++ b/src/youngtae/week5/Week5_15903.java
@@ -1,0 +1,50 @@
+package youngtae.week5;
+
+import java.io.*;
+import java.util.*;
+
+public class Week5_15903 {
+
+	static int N, M;
+	static long result;
+	static PriorityQueue<Long> pq = new PriorityQueue<>();
+
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+		StringBuilder sb = new StringBuilder();
+
+		StringTokenizer str = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(str.nextToken());
+		M = Integer.parseInt(str.nextToken());
+
+		str = new StringTokenizer(br.readLine());
+		for(int i = 0; i < N; i++) {
+			pq.add(Long.parseLong(str.nextToken()));
+		}
+
+		// 작은 점수를 만들기 위해 최소 값 2개(x, y)를 뽑아 더한다.
+		for(int i = 0; i < M; i++) {
+			long x = pq.poll();
+			long y = pq.poll();
+
+			// x, y 값 덮어쓰기
+			for(int j = 0; j < 2; j++) {
+				pq.add(x+y);
+			}
+		}
+
+		for(long i : pq) {
+			result += i;
+		}
+
+		sb.append(result);
+
+		bw.write(sb.toString());
+		bw.flush();
+		br.close();
+		bw.close();
+	}
+
+
+}


### PR DESCRIPTION
## ✍️작성자
>  권영태

## 📝풀이 내용

> 10330 (비트 문자열 재배열하기)
>> 맨 처음에 `0->1, 1->0`으로 변경하면 되는지 알았던 문제였다. 하지만 예제 출력 값이 너무나 달라서 아님을 알았고,  한칸 한칸 이동시키는 방법임을 알기까지 시간이 걸렸음.  문자열의 시작은 무조건 `0 또는 1`로 시작하기 때문에
그래서 연속코드와 일치하는 문자열 2개(0 시작 || 1 시작)을 만들고 각 문자열의 0과 1의 개수가 본 문자열의 0과 1의 개수와 일치하는지 검증하여 정답 문자열을 찾아낸다.
이후 본 문자열이 정답 문자열로 바뀌기 위해서 몇번의 스왑이 필요한지 계산(ed-st)하여 최소 횟수를 구한다.

> 11000 (강의실 배정)
>> union-find로 각 집합을 만들어서 루트 집합의 개수를 구하면 되겠다고 생각하고 접근했음. 
**하지만 강의 시간의 범위가 `0 ≤ Si < Ti ≤ 10^9` 로 되어 있어서 union-find를 위한 배열 arr의 크기가 너무 커짐 ==> 메모리 초과**
그래서 특정 강의의 종료시간과 시작시간을 잘 연결해서 계산하면 되지 않을까 싶은 접근법을 생각함.
Node 클래스의 comparable를 `o1.end -o2.start` 이런 식으로 구현해서 시도해봤는데 원하는대로 잘 이루어지지 않았음 😢 
어떻게 하면 될지 고민하다가 힌트(정답)을 확인하였음..
오름차순 시작시간 순(같다면 종료시간 순)으로 정렬시킨 강의 시간 배열을 우선순위 큐 `pq`에  모든 강의의 종료 시간을 하나씩 넣으면 된다.
이때 강의 종료 시간을 넣기 전, 해당 강의 시작 시간이 이전 강의의 가장 빠른 종료 시간(pq)을 비교한다.
비교를 통해 종료 시간보다 크거나 같다면 해당 강의실에서 이어서 진행할 수 있음을 나타내기에 이전 강의 종료 시간을 뺀 뒤 새로 채운다.

> 15903 (카드 합체 놀이)
>> 풀이 문제 중 가장 쉬웠던 문제! 오름차순 우선순위 큐에 각 카드를 집어넣은 뒤에 카드 합체 수만큼 가장 작은 숫자끼리 꺼내 더한 결과값을 우선순위 큐에 2번씩 집어넣어준다.  이후 큐에 있는 모든 수를 더하면 끝!

## 💬리뷰 요구사항(선택)

> 강의실 배정을 union-find로는 절대 못풀겠죠?

