### PR TITLE
[week6] 김희진

### DIFF
--- a/src/heejin/week6/Week6_11559.java
+++ b/src/heejin/week6/Week6_11559.java
@@ -1,0 +1,101 @@
+package heejin.week6;
+
+import java.util.*;
+import java.io.*;
+
+public class Week6_11559 {
+
+    static int N = 12, M = 6;
+    static int cnt;
+    static char[][] map;
+    static List<int[]> removed;
+    static int[][] dir = {{-1, 0}, {1, 0}, {0, -1}, {0, 1}};
+    static Queue<int[]> queue = new LinkedList<>();
+    static boolean[][] visited = new boolean[N][M];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        map = new char[N][M];
+        for (int i = 0; i < N; i++) {
+            map[i] = br.readLine().toCharArray();
+        }
+
+        while (startRound()) {
+            // 한 줄씩 뿌요 아래로 떨어짐
+            for (int j = 0; j < M; j++) {
+                down(j);
+            }
+
+            cnt++;
+            visited = new boolean[N][M];
+        }
+
+        System.out.print(cnt);
+    }
+
+    static boolean startRound() {
+        boolean flag = false; // 이번 라운드에서 뿌요가 터졌는지
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < M; j++) {
+                if (map[i][j] != '.' && !visited[i][j]) {
+
+                    removed = new ArrayList<>();
+                    int tempCnt = bfs(i, j);
+
+                    if (tempCnt >= 4) {
+                        flag = true;
+
+                        // 제거된 뿌요 다 빈 칸으로 만들기
+                        for(int[] cur : removed){
+                            map[cur[0]][cur[1]] = '.';
+                        }
+                    }
+                }
+            }
+        }
+        return flag;
+    }
+
+    static int bfs(int sx, int sy) {
+        int cnt = 1;
+        queue.add(new int[]{sx, sy});
+        visited[sx][sy] = true;
+        removed.add(new int[]{sx, sy});
+
+        while (!queue.isEmpty()) {
+            int[] cur = queue.poll();
+
+            for (int d = 0; d < 4; d++) {
+                int nx = cur[0] + dir[d][0];
+                int ny = cur[1] + dir[d][1];
+
+                if (nx < 0 || ny < 0 || nx >= N || ny >= M) continue;
+                if (visited[nx][ny] || map[nx][ny] != map[cur[0]][cur[1]]) continue;
+
+                visited[nx][ny] = true;
+                queue.add(new int[]{nx, ny});
+                removed.add(new int[]{nx, ny});
+                cnt++;
+            }
+        }
+        return cnt;
+    }
+
+    static void down(int col) {
+        for (int toRow = N - 1; toRow > 0; toRow--) {
+            if (map[toRow][col] == '.') {
+                int fromRow = toRow - 1;
+
+                // 빈 칸 아닌 시점까지 위로 이동
+                while(fromRow > 0 && map[fromRow][col] == '.'){
+                    fromRow--;
+                }
+
+                map[toRow][col] = map[fromRow][col];
+                map[fromRow][col] = '.';
+            }
+        }
+    }
+}

--- a/src/heejin/week6/Week6_13164.java
+++ b/src/heejin/week6/Week6_13164.java
@@ -1,0 +1,42 @@
+package heejin.week6;
+
+import java.io.*;
+import java.util.*;
+
+public class Week6_13164 {
+
+    static int N, K;
+    static long ans;
+    static int[] diff;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        diff = new int[N - 1];
+
+        st = new StringTokenizer(br.readLine());
+
+        int pre = Integer.parseInt(st.nextToken());
+        int cur;
+
+        // 간격 저장
+        for (int i = 0; i < N - 1; i++) {
+            cur = Integer.parseInt(st.nextToken());
+            diff[i] = cur - pre;
+            pre = cur;
+        }
+
+        // 간격 오름차순 정렬
+        Arrays.sort(diff);
+
+        // K개의 그룹으로 만드려면 N-K번 합쳐야 함
+        for (int i = 0; i < N - K; i++) {
+            ans += diff[i];
+        }
+
+        System.out.print(ans);
+    }
+}

--- a/src/heejin/week6/Week6_17142.java
+++ b/src/heejin/week6/Week6_17142.java
@@ -1,0 +1,100 @@
+package heejin.week6;
+
+import java.io.*;
+import java.util.*;
+
+public class Week6_17142 {
+
+    static int N, M, zeroCnt, min = Integer.MAX_VALUE;
+    static int[][] map, active;
+    static List<int[]> virus;
+    static int[][] dir = {{-1, 0}, {1, 0}, {0, -1}, {0, 1}};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        virus = new ArrayList<>();
+        active = new int[M][2];
+        map = new int[N][N];
+
+        // 입력
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+
+                if(map[i][j] == 2) virus.add(new int[]{i, j});
+                else if(map[i][j] == 0) zeroCnt++;
+            }
+        }
+
+        // 빈 칸이 없는 경우
+        if(zeroCnt == 0){
+            System.out.print(0);
+            return;
+        }
+
+        dfs(0,0);
+
+        System.out.print(min == Integer.MAX_VALUE ? -1 : min);
+    }
+
+    // 활성 상태 모든 경우의 수 탐색
+    static void dfs(int start, int activeCnt) {
+        if (activeCnt == M) {
+            min = Math.min(min, bfs());
+            return;
+        }
+
+        for (int i = start; i < virus.size(); i++) {
+            int[] cur = virus.get(i);
+
+            // 활성화된 바이러스 저장
+            active[activeCnt] = cur;
+
+            dfs(i + 1, activeCnt + 1);
+        }
+    }
+
+
+    static int bfs() {
+        boolean[][] visited = new boolean[N][N];
+        Queue<int[]> queue = new LinkedList<>();
+        int cnt = 0, tempTime = 0;
+
+        // 활성화된 바이러스 넣기
+        for(int[] start : active){
+            queue.add(new int[]{start[0], start[1], 0});
+            visited[start[0]][start[1]] = true;
+        }
+
+        while (!queue.isEmpty()) {
+            int[] cur = queue.poll();
+
+            for (int d = 0; d < 4; d++) {
+                int nx = cur[0] + dir[d][0];
+                int ny = cur[1] + dir[d][1];
+
+                if (nx < 0 || ny < 0 || nx >= N || ny >= N) continue;
+                if(visited[nx][ny] || map[nx][ny] == 1) continue;
+
+                // 비활성화 바이러스 or 빈 칸
+                queue.add(new int[]{nx, ny, cur[2] + 1});
+                visited[nx][ny] = true;
+
+                if(map[nx][ny] == 0){
+                    cnt++;
+                    tempTime = Math.max(tempTime, cur[2] + 1);
+                }
+            }
+        }
+
+        if(cnt != zeroCnt) return Integer.MAX_VALUE;
+
+        return tempTime;
+    }
+}

--- a/src/heejin/week6/Week6_9519.java
+++ b/src/heejin/week6/Week6_9519.java
@@ -1,0 +1,44 @@
+package heejin.week6;
+
+import java.io.*;
+import java.util.*;
+
+public class Week6_9519 {
+
+    static int X;
+    static String data;
+    static StringBuilder sb = new StringBuilder();
+    static List<String> rule = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        X = Integer.parseInt(br.readLine());
+        data = br.readLine();
+
+        // 반복되는 규칙 찾기
+        String first = data;
+        sb.append(first);
+
+        do {
+            data = sb.toString();
+            rule.add(data);
+
+            sb = new StringBuilder();
+
+            // 홀수번째 글자가 앞으로
+            for (int i = 0; i < data.length(); i += 2) {
+                sb.append(data.charAt(i));
+            }
+
+            // 짝수번째 글자 거꾸로 뒤로
+            int last = data.length() % 2 == 0 ? data.length() - 1 : data.length() - 2;
+            for (int j = last; j >= 0; j -= 2) {
+                sb.append(data.charAt(j));
+            }
+
+        } while (!sb.toString().equals(first));
+
+        System.out.print(rule.get(X % rule.size()));
+    }
+}


### PR DESCRIPTION
## ✍️작성자

> 김희진

## 📝풀이 내용

> 13164 행복한 유치원

- 앞 뒤 간격을 diff 배열에 저장한다.
- 간격을 기준으로 오름차순으로 정렬한다.
- K개의 그룹을 만들기 위해서는 N-K번 합치면 된다.
  - ex) N=5, K=2일 때 (1,4)로 나누든 (2,3)으로 나누든 3번을 합치면 된다.
  - 합친다 = 같은 그룹으로 만든다

> 9519 졸려

- 거꾸로 섞다 보면 다시 처음 단어로 돌아오게 되므로, 주기를 찾을 때까지 거꾸로 섞는 과정을 반복한다.
- 거꾸로 섞는 방법은 다음과 같다.
  - 홀수 번째 글자는 순서대로 앞으로 온다.
  - 짝수 번째 글자는 거꾸로 뒤로 온다.
  - ex) acefdb -> 홀수번째 글자 aed + 짝수번째 글자 거꾸로 bfc => aedbfs
- 거꾸로 섞은 결과가 처음 단어와 동일하다면, 주기가 끝난 것이다. 
- 주어진 X를 주기(rule의 크기)로 나눈 값을 인덱스로 하여 답을 찾는다.

> 11559 Puyo Puyo

- 한 라운드에서 제거될 수 있는 뿌요를 bfs를 사용해 찾는다.
  - 각 bfs함수는 시작점을 기준으로 주변에 동일한 색의 뿌요가 몇 개 인지 반환한다.
- 만약 동일 색의 뿌요가 4개 이상이라면 해당 범위는 제거될 수 있다.
- 이번 라운드에서 제거 가능한 뿌요가 없다면 게임을 종료한다.
- 그렇지 않다면 한줄 씩 빈칸 위에 있는 뿌요가 아래로 떨어진다.
  - 각 줄의 아래부터 빈 칸을 찾는다.
  - 그 위의 빈 칸이 아닌 시점을 찾고, 해당 값을 이전에 찾은 빈 칸으로 옮긴다.

> 17142 연구소 3

- 입력을 받으며 바이러스 위치와 빈 칸 개수를 저장한다.
- 빈 칸이 없는 경우, 0을 출력하고 리턴한다.
- 이전에 저장한 바이러스 위치를 이용해 M개를 활성 상태로 만드는 모든 경우의 수를 탐색한다.
  - active 배열에 현재 활성화된 바이러스 위치를 저장한다.
  - 활성화된 개수가 M개가 되면 bfs를 호출해 주변 빈 칸에 바이러스를 퍼뜨린다.
- bfs 함수에서 active 배열에 있는 위치를 queue에 넣어 초기화한다.
  - 주변의 비활성화 바이러스나 빈 칸을 만나면 queue에 넣고 방문 여부를 표시한다.
  - 빈 칸은 추가로, 빈칸 카운트와 최소 시간을 업데이트한다.
  - 마지막에 빈 칸 카운트가 처음 입력 받아 저장했던 빈 칸 개수와 일치하지 않다면 모든 빈 칸에 바이러스를 퍼뜨릴 수 없다.
  - 그렇지 않으면 최소 시간을 반환한다.

## 💬리뷰 요구사항(선택)
