### PR TITLE
[week7] 황지연

### DIFF
--- a/src/jiyeon/week7/boj_17940.java
+++ b/src/jiyeon/week7/boj_17940.java
@@ -1,0 +1,141 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+public class boj_17940 {
+	
+	/*
+	 * 최적의 출근 경로 : (1) 환승 횟수를 최소로하는 경로 중 /// (2) 소요시간이 가장 짧은 경로 
+	 * 
+	 * dist 배열은 최소 갱신 테이블로 
+	 * 	 - dist[i][0] :  출발지에서 i 번째 역으로 가는 최소 환승 횟수
+	 * 	 - dist[i][1] : 출발지에서 i 번째 역으로 가는 최소환승 횟수 중 최소 비용을 의미한다.
+	 * 
+	 * PriorityQueue의 우선순위 1. 환승 여부 2. 이동 시간 
+	 * 
+	 * */
+
+	
+	static int N,M; //지하철 수 , 도착지
+	static int[][] dist ; //최소 갱신 테이블 
+	static int[] subwayCompany; //각 지하철 운영 회사
+	static boolean [] visited; //노드 방문 여부 
+	static ArrayList<ArrayList<Subway>> graph = new ArrayList<>() ; //ArrayList.get(i) == i번째 지하철 역의 연결된 정보 
+	static final int INF = 1001;
+	
+	static class Subway implements Comparable<Subway>{
+		
+		private int transfer; //환승 여부 (0:환승 X , 1:환승 O)
+		private int nextSub; //연결된 지하철역
+		private int time; //연결된 지하철 역으로 가는 시간
+		
+		public Subway(int transfer, int nextSub, int time) {
+			this.transfer = transfer;
+			this.nextSub = nextSub;
+			this.time = time;
+		}
+
+
+		@Override
+		public int compareTo(Subway o1) {
+			if(this.transfer == o1.transfer)
+				return this.time - o1.time;
+			
+			return this.transfer - o1.transfer;
+		}
+		
+		
+	}//class - subway
+	
+	public static void main(String[] args) throws IOException{
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		
+		dist = new int[N][2];
+		visited = new boolean[N];
+		subwayCompany = new int[N];
+		
+		for(int i=0; i<N; i++) {
+			subwayCompany[i] = Integer.parseInt(br.readLine());
+			graph.add(new ArrayList<Subway>());
+			dist[i][0] = INF;
+			dist[i][1] = INF;
+		} // init
+		
+		
+		
+		for(int i=0; i<N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for(int j=0; j<N; j++) {
+				
+				int time = Integer.parseInt(st.nextToken());
+				if (time == 0) continue; //지하철이 연결되지 않은 경우 건너뛰기
+				int transfer = 0;
+				if(subwayCompany[i]!=subwayCompany[j]) transfer = 1; // 각 지하철의 운영 회사가 다를 경우 환승
+				int nextSub = j;
+				
+				graph.get(i).add(new Subway(transfer,nextSub,time));
+				
+			}
+			
+		} //input
+		
+		
+		//다익스트라 진행 
+		
+		dij();
+		
+		System.out.println(dist[M][0]+" "+dist[M][1]);
+		
+		
+
+	}//main
+	
+	
+	
+	//다익스트라 
+	
+	static void dij() {
+		
+		PriorityQueue<Subway> pq = new PriorityQueue<>();
+		pq.add(new Subway(0,0,0));
+		dist[0][0]=0;
+		dist[0][1]=0;
+		
+		while(!pq.isEmpty()) {
+			
+			Subway current = pq.poll();
+			
+			if(visited[current.nextSub])
+				continue;
+
+			
+			visited[current.nextSub] = true;
+			
+			for(Subway next : graph.get(current.nextSub)) {
+				int newTransfer = current.transfer+next.transfer;
+				int newTime = current.time+next.time;
+				
+				if(dist[next.nextSub][0]>newTransfer || (dist[next.nextSub][0]==newTransfer && dist[next.nextSub][1]>newTime)) {
+					
+					dist[next.nextSub][0] = newTransfer;
+					dist[next.nextSub][1] = newTime;
+					pq.add(new Subway(newTransfer,next.nextSub,newTime));
+					
+				}
+				
+			}
+			
+		}
+		
+	}//dij
+	
+	
+
+}

--- a/src/jiyeon/week7/boj_20160.java
+++ b/src/jiyeon/week7/boj_20160.java
@@ -1,0 +1,174 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+public class boj_20160 {
+	
+	
+	/*
+	 * 아줌마가 출발지에서 i번째 지점으로 가는 <누적> 시간과 내가 출발지에서 i번째 지점으로 가는 시간을 비교한다. 
+	 *  => 내가 가는 시간이 더 빠르거나 같으면 해당 지점 번호를 반환 , 여러 개면 제일 작은 번호를 반환 
+	 * 
+	 * 주의할 점 : 아주머니가 이동 하실 때 i->i+1번째로 가는 방법이 없으면 i+2지점으로 감 
+	 * 주의할 점 2 : visited배열과 dist 배열은 이동할 때마다 초기화 해줘야함
+	 * 
+	 * 출발지로부터 다익스트라 한 결과, dist[목적지] = INF 라면 해당 목적지까지 갈 수 없다는 뜻이다.
+	 * 
+	 * */
+	
+	static int V,E,myStart, answer;
+	static long time; //야쿠르트 아줌마의 이동 시간 누적합 
+	static ArrayList<ArrayList<Node>> graph = new ArrayList<>();
+	static boolean [] visited, visited2; //야쿠르트 아줌마, 나의 방문 배열 
+	static int [] dist, dist2; //야쿠르트 아줌마의 최소거리 배열 , 나의 최소 거리 배열
+	static int [] order = new int[10]; //야쿠르트 아줌마의 경로
+	
+	static class Node implements Comparable<Node>{
+		
+		private int v;
+		private int w;
+		
+		public Node(int v, int w) {
+			this.v = v;
+			this.w = w;
+		}
+		
+		
+		@Override
+		public int compareTo(Node o1) {
+			
+			if(this.w == o1.w)
+				return this.v - o1.v;
+			
+			return this.w - o1.w;
+		}
+
+	} //inner class : Node
+	
+	
+	
+	public static void main(String[] args) throws IOException {
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		V = Integer.parseInt(st.nextToken()); //정점
+		E = Integer.parseInt(st.nextToken()); //간선 
+		answer = Integer.MAX_VALUE;
+		
+		visited = new boolean[V+1];
+		visited2 = new boolean[V+1];
+		dist = new int[V+1];
+		dist2 = new int[V+1];
+		
+		for(int i=0; i<=V; i++) {
+			graph.add(new ArrayList<Node>());
+			dist[i] = Integer.MAX_VALUE;
+			dist2[i] = Integer.MAX_VALUE;
+		}//init
+		
+		
+		for(int i=0; i<E; i++) {
+			st = new StringTokenizer(br.readLine());
+			
+			int u = Integer.parseInt(st.nextToken());
+			int v = Integer.parseInt(st.nextToken());
+			int w = Integer.parseInt(st.nextToken());
+			
+			//양방향 연결
+			graph.get(u).add(new Node(v,w));
+			graph.get(v).add(new Node(u,w));
+			
+		}//graph input
+		
+		st = new StringTokenizer(br.readLine());
+		for(int i=0; i<10; i++)
+			order[i] = Integer.parseInt(st.nextToken());
+		
+		myStart = Integer.parseInt(br.readLine()); //나의 시작 지점
+		//input 
+		
+		if(order[0]==myStart){
+			System.out.println(myStart); //아줌마와 나의 맨 처음 시작 지점이 같을 경우 탐색하지 않고 결과 반환
+		}
+		else {
+			
+			int yogurtGirlStart = order[0]; //야구르트 아줌마 출발 지점
+			
+			for(int i=1; i<10; i++) {
+				
+				//방문 배열, 거리 배열 초기화 
+				Arrays.fill(visited, false);
+				Arrays.fill(visited2, false);
+				Arrays.fill(dist, Integer.MAX_VALUE);
+				Arrays.fill(dist2, Integer.MAX_VALUE);
+				
+				int yogurtGirlEnd = order[i]; //야구르트 아줌마 도착 지점 
+				
+				dij(yogurtGirlStart,yogurtGirlEnd,dist,visited); 
+				dij(myStart,yogurtGirlEnd,dist2,visited2);
+				
+				if(dist[yogurtGirlEnd] == Integer.MAX_VALUE) {
+					continue;
+				}//야쿠르트 아줌마가 이동하실 수 없는 경우 
+				
+				yogurtGirlStart = yogurtGirlEnd; //아줌마가 이동하실 수 있을 때만 시작 지점 갱신
+				
+				if(dist2[yogurtGirlEnd] == Integer.MAX_VALUE) {
+					continue; 
+				}//내가 이동할 수 없는 경우
+				
+				
+				time += dist[yogurtGirlEnd];
+
+				if(time>=dist2[yogurtGirlEnd])
+					answer = Math.min(answer,yogurtGirlEnd);
+				
+			}
+			
+			
+			if(answer==Integer.MAX_VALUE)
+				answer = -1;
+			
+			System.out.println(answer);
+			
+		}
+		
+	}//main
+	
+	
+	//다익스트라 메서드 
+	static void dij(int start, int end, int[] dist, boolean [] visited) {
+		
+		PriorityQueue<Node> pq = new PriorityQueue<>();
+		
+		pq.add(new Node(start,0));
+		
+		dist[start] = 0;
+		
+		while(!pq.isEmpty()) {
+			
+			Node current = pq.poll();
+			
+			if(visited[current.v])
+				continue;
+			
+			visited[current.v] = true;
+			
+			for(Node next : graph.get(current.v)) {
+				
+				if(dist[next.v]> current.w+next.w) {
+					
+					dist[next.v] = current.w+next.w;
+					pq.add(new Node(next.v,current.w+next.w));
+					
+				}
+				
+			}
+			
+		}
+
+	}//dij
+
+}

--- a/src/jiyeon/week7/boj_31938.java
+++ b/src/jiyeon/week7/boj_31938.java
@@ -1,0 +1,179 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+
+public class boj_31938 {
+
+	
+	static class Node implements Comparable<Node>{
+		
+		private int v; //이어진 정점 
+		private long w; //가중치 
+		
+		public Node(int v, long w) {
+			this.v = v;
+			this.w = w;
+		}
+
+		@Override
+		public int compareTo(Node o1) {
+			
+			if(this.w == o1.w)
+				return this.v - o1.v;
+			
+			return Long.compare(this.w, o1.w);
+		}
+		
+	}//Node
+	
+	
+	static int N, M; //도시 개수, 도로 개수 
+	static long answer;
+	static ArrayList<ArrayList<Node>> graph = new ArrayList<>();
+	static boolean [] visited; //방문 배열 
+	static long [] dist; // dist[i] : i 번째 노드까지의 최소 누적 비용 
+	static Node [] prev; 
+	// prev[i].v : i 번째 노드의 바로 전 노드 / prev[i].w : 직전 간선 비용 (prev[i].v 와 자기 자신의 비용)
+	static int [] childNodeNum; //childNodeNum[i] = n ; 정점 i 자기 자신을 포함한 자식 노드의 개수는 n이다. 
+	static long [] bestParentCost; //i번째 노드로 오기 위해 사용한 경로에서 직전 노드까지의 누적비용 
+
+	public static void main(String[] args) throws IOException {
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		visited = new boolean[N+1];
+		dist = new long[N+1];
+		childNodeNum = new int[N+1];
+		prev = new Node[N+1];
+		bestParentCost = new long[N+1];
+		
+		Arrays.fill(dist, Integer.MAX_VALUE);
+		Arrays.fill(bestParentCost, -1);
+		
+		for(int i=0; i<=N; i++) {
+			graph.add(new ArrayList<Node>());
+		}//initialize
+		
+		
+		for(int i=0; i<M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			int c = Integer.parseInt(st.nextToken());
+			
+			//양방향 연결 
+			graph.get(a).add(new Node(b,c));
+			graph.get(b).add(new Node(a,c));
+			
+		}
+		//input
+		
+		prev[1] = new Node(0,0); // 출발지 초기화
+		
+		dij(); 
+		
+
+		//prev 배열을 이용해서 다익스트라 이후 트리 구성
+		
+		List<Integer>[] tree = new ArrayList[N+1];
+		for(int i=0; i<=N; i++) {
+			tree[i] = new ArrayList<>(); 
+		}
+		
+		for(int i=2; i<=N; i++) {
+			tree[prev[i].v].add(i);
+		}
+		
+		
+		//위의 트리를 기준으로 DFS 이용하여 자식 노드 개수 구하기
+		dfs(1,tree);
+
+		
+		//최종 비용 계산하기
+		for(int i=2; i<=N; i++) {
+			
+			answer += (9*childNodeNum[i]+1)*prev[i].w/10;
+		}
+		//정답 출력
+		System.out.println(answer);
+		
+
+	}//main
+	
+	
+	//DFS : node의 자식 노드 개수를 카운트 하는 용도 
+	static int dfs(int node, List<Integer>[] tree) {
+		int count = 1; 
+		for(int child : tree[node]) {
+			count += dfs(child,tree);
+		}
+		
+		childNodeNum[node] = count;
+		return count;
+		
+	}
+	
+	
+	//다익스트라 메서드 
+	static void dij() {
+		
+		PriorityQueue<Node> pq = new PriorityQueue<>();
+		dist[1] = 0; //출발지는 무조건 1
+		pq.add(new Node(1,0));
+		
+		while(!pq.isEmpty()) {
+			
+			Node current = pq.poll();
+			
+			if(visited[current.v])
+				continue;
+			
+			visited[current.v] = true;
+
+			for(Node next : graph.get(current.v)) {
+				long newCost = dist[current.v] + next.w;
+				
+				//조건 1 : 더 짧은 경로를 발견하면 무조건 갱신 
+				if(dist[next.v] > newCost) {
+					
+					dist[next.v] = newCost;
+					prev[next.v] = new Node(current.v,next.w);
+					bestParentCost[next.v] = dist[current.v]; // 부모 누적 비용 저장
+					pq.add(new Node(next.v, newCost));
+
+				}
+				//조건 2 : 만약 총 비용이 같을 경우, 현재 경로의 누적 비용(dist 배열)이 이전에 저장한 부모 누적 비용(bestParentCost)보다 크면 갱신
+				/*
+				 * 예제를 보면 5번째 노드로 가는 경우의 수는 
+				 * 1. 1 -> 2 -> 3 -> 5
+				 * 2. 1 -> 2 -> 4 -> 5 (정답)
+				 * 
+				 * 이렇게 2가지가 있습니다. 우리가 최적의 할인을 받기 위해서는 5 번째 노드까지 오는 경로 중에서 직전 노드까지의 누적비용이 "큰" 경로를 선택해야 할인을 많이 받을 수 있습니다.
+				 * 
+				 * 다익스트라를 진행하게 되면 조건 1에 의해서 먼저  1 -> 2 -> 3 -> 5의 경로 중 5의 직전 노드인 3까지 오는 비용이 bestParent[5]에 저장됩니다. (bestParent[5] = 30)
+				 * 이후 1 -> 2 -> 4 -> 5 경로를 검증하는 구간에서 두 경로의 총 비용이 같으니깐 조건 2로 오게 됩니다. 이 때 1->2->4 까지의 비용에 해당하는 dist[4]의 비용이 40으로, bestParent[5]의 값보다 크니 
+				 * 해당 경로를 선택하게 되고, prev배열과 bestParentCost배열을 갱신합니다.
+				 * 
+				 * */
+				else if(dist[next.v] == newCost) {
+                    if (bestParentCost[next.v] == -1 || dist[current.v] > bestParentCost[next.v]) {
+                    	
+                        prev[next.v] = new Node(current.v, next.w);
+                        bestParentCost[next.v] = dist[current.v];
+                    }
+				}
+				
+			}
+		}
+		
+		
+	}//dij
+	
+	
+
+}


### PR DESCRIPTION
## ✍️작성자

>황지연

## 📝풀이 내용

_모든 문제의 구현 설명은 코드 내 주석으로 달아두었습니다!_ PR에는 문제 접근 로직만 작성하였습니다.

> **17940번 지하철** 

 이 문제의 핵심은 무조건 최단 경로를 구하는 것이 아니라, "환승 횟수를 최소로 하는 경로 중" 최단 경로를 구하는 것이다.
 이를 고려해주기 위해 최소 비용 갱신 테이블을 i x 2 크기의 배열로 만들어
- dist[i][0] :  출발지에서 i 번째 역으로 가는 최소 환승 횟수
- dist[i][1] : 출발지에서 i 번째 역으로 가는 최소환승 횟수 중 최소 비용

을 저장하도록 하였다. 

이후 다익스트라 메서드에서 탐색을 할 때, 
 1. 환승 횟수가 기존 보다 적다면 무조건 dist 테이블 갱신 
 2. 만약 환승횟수가 같을 경우에는 최소비용인 쪽으로 갱신 해주었습니다.
----
>
> **20160번 야쿠르트 아줌마 야쿠르트 주세요**
>
>
이 문제의 핵심은 야쿠르트 아줌마는 무조건 주어진 경로를 따라가야하는 반면, 나의 경우에는 출발지에서 바로 해당 목적지까지 가도 된다는 것이다. 
또한, 문제 풀이 할때 주의할 점이 있는데 

1.  아줌마는 주어진 경로를 따라가지만, 다음 목적지로 이동할 수 없으면 그 다음 목적지로 건너뛴다는 것이다. 
- 이 경우 아줌마의 출발지를 갱신하면 안된다. 🥲 이걸 고려 안해줘서 좀 틀렸다.
2. 내가 가는 시간이 아주머니보다 더 빠르거나 같으면 해당 번호가 정답인데, 그런 번호가 여러 개이면 제일 작은 번호를 반환하는 것이다.
- 이 조건 떄문에 중간에 break를 할 수 없고 무조건 경로를 다 돌려봐야한다...
3. 아줌마의 첫 번째 출발지와 나의 출발지가 같으면 다익스트라를 안하고 바로 해당 출발지를 반환하면 된다.

위 주의 사항만 잘 고려하면 이 후 구현 방법은 간단하다. 
 다익스트라 메서드에 출발지 파라미터를 하나 추가해줘서 해당 출발지부터의 아줌마의 최단 경로를  탐색한 후 나의 최단 경로와 비교해주었다. 

----
>
>**31938번 현대모비스 트럭 군집 주행**
>
> 
 이 문제의 핵심은 할인율을 생각하면서 + 최단 거리를 구해야 한다는 것이다.
이 핵심 로직만 잘 생각하면 구현하는 것은 어렵지 않다. 하지만 생각하는게 힘들다 

여러 가지 방법이 있겠다만, 나는  타겟 노드의 **""직전"" 노드까지 오는 누적 합**을 비교하는 로직으로 답을 도출해내었다.

![image](https://github.com/user-attachments/assets/169659c2-4ef9-4f0c-86cb-6a43612097ab)

예제의 경우 5번째 노드로 가는 최적의 경로를 도출하는 과정에서 
위와 같이 1번 경로로 오는 경우와 2번 경로로 오는 경우가 충돌하게 된다. 왜냐햐면 할인율을 생각하지 않았을 때의 두 경로의 총 비용이 같기 때문이다. 

이 경우, 최적의 경로를 선택하기 위해서는 5번 노드 직전의 노드인 3번 노드의 최소 비용과 4번 노드의 최소 비용을 비교해봤을 때, 더 큰 비용을 가진 노드를 고르는 것이 할인율을 높이는 방법이다. (_왜냐하면 5번 노드로 오는 총 비용이 같기 때문이다!!_)

4번 노드까지의 비용은 40, 3번 노드까지의 비용은 30 이기 때문에 4번 노드를 거쳐서 오는 경로를 선택하는 것이 가장 바람직한 경로이다!

자세한 구현 방법은 코드에 주석으로 달아놓았습니다. 
(사용한 자료 구조가 많아 헷갈릴 수 있습니다... 최대한 주석을 달아놨습니다..)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
>  현대모비스 트럭 군집 주행 문제를 푼 나만의 로직 혹은 제 코드에서 좀 더 최적화하면 좋을 부분을 알려주세요! 
