### PR TITLE
[week7] 양여은

### DIFF
--- a/src/yeoeun/week07/Week7_17940.java
+++ b/src/yeoeun/week07/Week7_17940.java
@@ -1,0 +1,90 @@
+package yeoeun.week07;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Week7_17940 {
+    static final int INF = 1000001; // (N)1000 * (E)1000
+    static int N, M;
+    static int[] stations, distance, transfer;
+    static int[][] graph;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        // 역 정보 입력받기
+        stations = new int[N];
+        for (int i = 0; i < N; i++) {
+            stations[i] = Integer.parseInt(br.readLine());
+        }
+
+        // 연결 정보 입력받기
+        graph = new int[N][N];
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < N; j++) {
+                graph[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        distance = new int[N];
+        transfer = new int[N];
+
+        Arrays.fill(distance, INF);
+        dijkstra(0);
+
+        System.out.println(transfer[M] + " " + distance[M]);
+    }
+
+    public static void dijkstra(int start) {
+        // 환승 횟수 기준 -> 거리순 정렬
+        PriorityQueue<Node> queue = new PriorityQueue<>(Comparator.comparing((Node n) -> n.transfer).thenComparing(n -> n.cost));
+        boolean[] visited = new boolean[N];
+
+        queue.add(new Node(start, 0, 0));
+        distance[start] = 0;
+
+        while(!queue.isEmpty()) {
+            Node now = queue.poll();
+
+            // 방문여부 체크
+            if(visited[now.idx]) continue;
+            else visited[now.idx] = true;
+
+            for (int next = 0; next < N; next++) {
+                if(graph[now.idx][next] == 0) continue;
+
+                if(!visited[next] && distance[next] > now.cost + graph[now.idx][next]) {
+                    // 환승 정보 : 다르면 증가
+                    transfer[next] = (stations[now.idx] != stations[next]) ? transfer[now.idx] + 1 : transfer[now.idx];
+
+                    // 거리 정보 갱신
+                    distance[next] = now.cost + graph[now.idx][next];
+
+                    // 큐 삽입
+                    queue.add(new Node(next, transfer[next], distance[next]));
+                }
+            }
+        }
+    }
+
+    public static class Node {
+        int idx;
+        int transfer;
+        int cost;
+
+        public Node (int idx, int transfer, int cost) {
+            this.idx = idx;
+            this.transfer = transfer;
+            this.cost = cost;
+        }
+    }
+}

--- a/src/yeoeun/week07/Week7_20160.java
+++ b/src/yeoeun/week07/Week7_20160.java
@@ -1,0 +1,119 @@
+package yeoeun.week07;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Week7_20160 {
+    static int V, E;
+    static final int INF = 1000000001; // (V)10000 * (w)100000 기준
+    static List<List<Node>> graph = new ArrayList<>();
+    static int[][] distance;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        V = Integer.parseInt(st.nextToken());
+        E = Integer.parseInt(st.nextToken());
+
+        distance = new int[V+1][V+1];
+        for (int i = 0; i <= V; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < E; i++) {
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+            int w = Integer.parseInt(st.nextToken());
+
+            // 양방향
+            graph.get(s).add(new Node(e, w));
+            graph.get(e).add(new Node(s, w));
+        }
+
+        // 시작점 -> distance[] 정보 관리
+        HashMap<Integer, int[]> map = new HashMap<>();
+
+        // 아주머니 경로 저장
+        int[] route = new int[10];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < 10; i++) {
+            int rNum = Integer.parseInt(st.nextToken());
+            route[i] = rNum;
+        }
+
+        // 나 -> 다른 노드 최소 경로 계산
+        int mStart = Integer.parseInt(br.readLine());
+        map.put(mStart, dijkstra(mStart));
+
+        // 최종 계산
+        long yoTime = 0;
+        int min = INF;
+        if(route[0] != mStart) {
+            // 이전 -> 현재 이동 시간 계산
+            for (int i = 1; i < 10; i++) {
+                int src = route[i-1]; // 시작점
+
+                // 다익스트라 정보 넣기
+                if(!map.containsKey(src)) map.put(src, dijkstra(src));
+
+                // 가능한 다음 도착지 탐색
+                int distance = map.get(src)[route[i]];
+                while(distance == INF && ++i < 10) {
+                    distance = map.get(src)[route[i]];
+                }
+
+                // dst가 10 이상이면 src가 마지막 지점
+                if(i == 10) break;
+
+                yoTime += distance;
+                int myTime = map.get(mStart)[route[i]];
+
+                // 가능하면 최소 노드 번호 구하기
+                if(yoTime != INF && myTime != INF && yoTime >= myTime) {
+                    min = Math.min(min, route[i]);
+                }
+            }
+        } else { // 동일 시작이면 무조건 바로 가능
+            min = route[0];
+        }
+        System.out.println(min == INF ? -1 : min);
+    }
+
+    public static int[] dijkstra(int start) {
+        PriorityQueue<Node> pq = new PriorityQueue<>(Comparator.comparing(n -> n.cost));
+        boolean[] visited = new boolean[V+1];
+        int[] distance = new int[V+1];
+
+        Arrays.fill(distance, INF);
+        pq.add(new Node(start, 0));
+        distance[start] = 0;
+
+        while(!pq.isEmpty()) {
+            Node now = pq.poll();
+
+            if(visited[now.idx]) continue;
+            else visited[now.idx] = true;
+
+            for (Node next : graph.get(now.idx)) {
+                if(!visited[next.idx] && distance[next.idx] > now.cost + next.cost) {
+                    distance[next.idx] = now.cost + next.cost;
+                    pq.add(new Node(next.idx, distance[next.idx]));
+                }
+            }
+        }
+        return distance;
+    }
+
+    public static class Node {
+        int idx;
+        int cost;
+
+        public Node(int idx, int cost) {
+            this.idx = idx;
+            this.cost = cost;
+        }
+    }
+}

--- a/src/yeoeun/week07/Week7_31938.java
+++ b/src/yeoeun/week07/Week7_31938.java
@@ -1,0 +1,88 @@
+package yeoeun.week07;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Week7_31938 {
+    static final long INF = Long.MAX_VALUE;
+    static int N, M;
+    static long[] distance, answer;
+    static List<List<Node>> graph = new ArrayList<>();
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        for (int i = 0; i <= N; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        // 그래프 정보 입력받기
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+
+            graph.get(s).add(new Node(e, c));
+            graph.get(e).add(new Node(s, c));
+        }
+
+        distance = new long[N+1]; // 실제 거리 정보 관리
+        answer = new long[N+1]; // 비용 정보 관리 (최종 답)
+        Arrays.fill(distance, INF);
+
+        dijkstra(1);
+
+        long total = 0L;
+        for (int i = 1; i <= N; i++) {
+            total += answer[i];
+        }
+        System.out.println(total);
+    }
+
+    public static void dijkstra (int start) {
+        PriorityQueue<Node> pq = new PriorityQueue<>(Comparator.comparing(n -> n.cost));
+        boolean[] visited = new boolean[N+1];
+
+        pq.offer(new Node(start, 0));
+        distance[start] = 0;
+
+        while(!pq.isEmpty()) {
+            Node now = pq.poll();
+
+            // 선택 노드 방문 처리
+            if(visited[now.idx]) continue;
+            else visited[now.idx] = true;
+
+            for (Node next : graph.get(now.idx)) {
+                long realCost = distance[now.idx] + next.cost;
+
+                // 미방문 && 새로운 distance가 최소인 경우(같아도 처리)
+                if(visited[next.idx] || distance[next.idx] < realCost) continue;
+
+                // 실제 거리(distance)는 같아도 감소한 거리값은 다를 수도 있음
+                // -> 같은 거리인 경우에도 업데이트 (savedCost는 항상 realCost보다 같거나 작으므로)
+                answer[next.idx] = (long) (distance[now.idx] * 0.9) + next.cost;
+
+                // 기존 경로(100%) 다익스트라 정보 갱신
+                distance[next.idx] = realCost;
+                pq.offer(new Node(next.idx, realCost));
+            }
+        }
+    }
+
+    public static class Node {
+        int idx;
+        long cost;
+
+        public Node (int idx, long cost) {
+            this.idx = idx;
+            this.cost = cost;
+        }
+    }
+}


### PR DESCRIPTION
## ✍️작성자

> 양여은

## 📝풀이 내용

> 🚉 17940 : 지하철

- Node 객체에 transfer이라는 정보를 추가하여 환승 횟수 정보를 관리하였습니다.
- 현재 역과 다음역이 다른 경우 transfer 값을 1씩 증가시켰습니다.
- PQ에서는 먼저 transfer 횟수를 기준으로 비교하고, 동일하다면 cost를 비교하도록 우선순위를 재설정하였습니다.

> 🧃 20160 : 야쿠르트 아줌마 야쿠르트 주세요

- 다익스트라 호출 횟수를 줄이기 위해, 탐색이 일어난 경우의 시작노드-distance[] 정보를 Map으로 관리하였습니다. 만약 출발노드가 map에 있다면 탐색을 하지 않고, 없는 경우에만 탐색을 하게 됩니다.
- 먼저, ‘나’의 각 노드까지의 거리를 계산하여 map에 등록합니다.
- 야쿠르트 아줌마: 시작 노드를 기준으로 다익스트라를 시행합니다. 이후, 도착 가능한 가장 가까운 지점을 계산합니다. (INF가 아닐때까지 i 증가)
- 각 경우 ‘나’와 만나는 것이 가능한지 계산 후 min 노드 번호를 구합니다.

> 🛻 31938 : 현대모비스 트럭 군집주행

- 한 번 사용된 도로는 90%가격으로 사용할 수 있다고 볼 수 있습니다. 즉, N번 노드까지의 최종 비용은 (이전 노드까지의 거리 * 0.9 + 마지막 경로 거리)이 됩니다.
- 최소 비용이 아닌, 최소 거리를 기준으로 트럭이 이동하기 때문에 기존 거리 정보를 기준으로 최단 경로를 탐색합니다.
- 단, distance는 같아도 비용이 다른 경우가 존재하기 때문에 새로운 distance가 기존의 distance와 같은 경우에도 answer 업데이트 로직을 실행합니다.
- 최종적으로 구해진 answer[] 값들을 모두 더해 최종 비용을 계산합니다.



## 💬리뷰 요구사항(선택)

> 다익스트라를 위한 객체를 만들 때 Edge/Node 중 보통 어떤걸 이름으로 많이 사용하나요..? 문제 풀 때마다 헷갈려서 여쭤봅니다!ㅠㅠ
