### PR TITLE
[week7] 이진우

### DIFF
--- a/src/jinu/week7/Week7_17940.java
+++ b/src/jinu/week7/Week7_17940.java
@@ -1,0 +1,146 @@
+package jinu.week7;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Week7_17940 {
+
+    // 정렬 시 환승 횟수가 가장 적은 것 , 환승 횟수가 같다면 시간 비용이 작은 것 선택
+    static class Node implements Comparable<Node> {
+        private int stationNumber;
+
+        private int timeCost;
+        private int transferCount;
+
+        public Node(int stationNumber,int timeCost,int transferCount){
+            this.stationNumber = stationNumber;
+            this.timeCost = timeCost;
+            this.transferCount = transferCount;
+        }
+
+
+        @Override
+        public int compareTo(Node n) {
+
+            if(this.transferCount == n.transferCount){
+                return this.timeCost-n.timeCost;
+            }
+
+            return this.transferCount - n.transferCount;
+        }
+    }
+
+    public static class Station {
+
+        private int stationNumber;
+        private int timeCost;
+
+        public Station(int stationNumber, int timeCost) {
+            this.stationNumber = stationNumber;
+            this.timeCost = timeCost;
+        }
+    }
+
+
+
+
+    static List<Station> graph[];
+
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+
+        // 배열 초기화
+        int stationCompanyInfo[] = new int[N];
+        boolean isVisited[] = new boolean[N];
+        graph = new List[N];
+
+        for(int i=0;i<N;i++){
+            st = new StringTokenizer(br.readLine());
+            int cInfo = Integer.parseInt(st.nextToken());
+            stationCompanyInfo[i] = cInfo;
+        }
+
+
+        // 출발점, 도착점 ,비용을 가진 그래프 형성
+        for(int i=0;i<N;i++){
+            graph[i] = new ArrayList<>();
+            st = new StringTokenizer(br.readLine());
+            for(int dest=0;dest<N;dest++){
+
+                int timeCost = Integer.parseInt(st.nextToken());
+                if(timeCost!=0){
+                    graph[i].add(new Station(dest,timeCost));
+                }
+            }
+        }
+
+
+
+        // 환승 횟수가 가장 적은 것, 시간 비용이 가장 적은 것 부터 차례대로 꺼냄.
+        PriorityQueue<Node> pq = new PriorityQueue<>();
+        pq.add(new Node(0,0,0));
+
+
+
+        // dist[i] : 출발점 부터 i 까지 갔을 때 최소 시간비용 , transferNum[i] : 출발점 부터 i까지 갔을 때 최소 환승 횟수
+        int dist[] = new int[N];
+        Arrays.fill(dist,Integer.MAX_VALUE);
+        dist[0] = 0;
+        int transferNum[] = new int[N];
+        Arrays.fill(transferNum,Integer.MAX_VALUE);
+        transferNum[0] = 0;
+
+
+
+
+        while(!pq.isEmpty()){
+
+            Node n = pq.poll();
+            if(isVisited[n.stationNumber]){
+                continue;
+            }
+
+            isVisited[n.stationNumber] = true;
+
+            // n의 stationNumber 에서 연결되는 Station s
+            for(Station s : graph[n.stationNumber]){
+
+                // 기존 역과 같은 회사에서 관리된다면 changeCount = 0 아니면 1
+                int changeCount = stationCompanyInfo[n.stationNumber]==stationCompanyInfo[s.stationNumber]?0:1;
+
+                // 갱신 조건: 환승횟수가 갱신되거나, 환승 횟수가 갱신되지 않아도 시간비용이 갱신되거나
+                if(transferNum[s.stationNumber]>transferNum[n.stationNumber]+changeCount ||
+                        ((transferNum[s.stationNumber]==transferNum[n.stationNumber] + changeCount) && (dist[s.stationNumber]>dist[n.stationNumber]+s.timeCost))){
+
+                    if(transferNum[s.stationNumber]>transferNum[n.stationNumber]+changeCount){
+                        transferNum[s.stationNumber] = transferNum[n.stationNumber] + changeCount;
+                    }
+
+                    dist[s.stationNumber] = dist[n.stationNumber]+s.timeCost;
+
+                    pq.add(new Node(s.stationNumber,dist[s.stationNumber],transferNum[s.stationNumber]));
+                }
+            }
+
+
+
+        }
+
+        System.out.println(transferNum[M]+" "+dist[M]);
+
+
+
+
+    }
+}

--- a/src/jinu/week7/Week7_20160.java
+++ b/src/jinu/week7/Week7_20160.java
@@ -1,0 +1,156 @@
+package jinu.week7;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Week7_20160 {
+
+    static class Node implements Comparable<Node>{
+        private int index;
+        private long cost;
+
+        public Node(int index, long cost) {
+            this.index = index;
+            this.cost = cost;
+        }
+
+        public int compareTo(Node n){
+            if(this.cost <= n.cost){
+                return -1;
+            }
+            return 1;
+        }
+
+    }
+
+    static class YogurtPosition{
+        int index;
+        long time;
+
+        public YogurtPosition(int index, long time) {
+            this.index = index;
+            this.time = time;
+        }
+    }
+
+    static List<Node> graph[];
+
+    static int V;
+
+    public static void main(String[] args) throws Exception{
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        V = Integer.parseInt(st.nextToken());
+        int E = Integer.parseInt(st.nextToken());
+
+
+        // 간선 저장.
+        graph = new List[V+1];
+        for(int i=1;i<=V;i++){
+            graph[i] = new ArrayList<>();
+        }
+        for(int i=0;i<E;i++){
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            int w = Integer.parseInt(st.nextToken());
+
+            graph[u].add(new Node(v,w));
+            graph[v].add(new Node(u,w));
+        }
+
+
+
+        // 요쿠르트 아줌마의 판매 경로 배열 저장
+        int []sellDestination = new int[10];
+        st = new StringTokenizer(br.readLine());
+        for(int i=0;i<10;i++){
+            sellDestination[i] = Integer.parseInt(st.nextToken());
+        }
+
+
+        // 각 판매 위치마다의 시간을 저장.
+        List<YogurtPosition> yogurtPositions = new ArrayList<>();
+        int startPoint = sellDestination[0];
+        long time = 0;
+        yogurtPositions.add(new YogurtPosition(startPoint,0));
+        for(int i=1;i<10;i++){
+
+            long distance = dijkstra(startPoint,sellDestination[i]);//다익스트라
+
+            if(distance == Long.MAX_VALUE){
+                continue;
+            }
+
+            yogurtPositions.add(new YogurtPosition(sellDestination[i],time+distance));
+            time += distance;
+            startPoint = sellDestination[i];
+
+        }
+
+
+
+
+        // 나의 위치에서 비교
+        int answer = -1;
+
+        st = new StringTokenizer(br.readLine());
+        int myStart = Integer.parseInt(st.nextToken());
+
+        for(YogurtPosition yogurtPosition : yogurtPositions){
+
+            long myTime = dijkstra(myStart,yogurtPosition.index);
+            if(myTime<=yogurtPosition.time){
+                if(answer == -1){
+                    answer = yogurtPosition.index;
+                }
+                else{
+                    answer = Math.min(answer,yogurtPosition.index);
+                }
+            }
+        }
+
+        System.out.println(answer);
+
+
+
+    }
+
+    public static long dijkstra(int start,int dest){
+
+        long dist[] = new long[V+1];
+        Arrays.fill(dist,Long.MAX_VALUE);
+        dist[start] = 0;
+        boolean isVisited[] = new boolean[V+1];
+
+        PriorityQueue<Node> pq = new PriorityQueue<>();
+        pq.add(new Node(start,0));
+
+        while(!pq.isEmpty()){
+            Node now = pq.poll();
+
+            if(isVisited[now.index]){
+                continue;
+            }
+
+            isVisited[now.index] = true;
+
+            for(Node next : graph[now.index]){
+                if(dist[next.index] > dist[now.index] + next.cost){
+                    dist[next.index] = dist[now.index] + next.cost;
+                    pq.add(new Node(next.index,dist[next.index]));
+                }
+            }
+        }
+
+        return dist[dest];
+
+    }
+}

--- a/src/jinu/week7/Week7_31938.java
+++ b/src/jinu/week7/Week7_31938.java
@@ -1,0 +1,236 @@
+package jinu.week7;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+
+public class Week7_31938 {
+
+
+    // start 부터 n 까지의 최단 거리
+    static long dist[];
+
+    static class Node implements Comparable<Node>{
+        private int from;
+        private int to;
+        private long cost;
+
+        public Node(int from, int to, long cost) {
+            this.from = from;
+            this.to = to;
+            this.cost = cost;
+        }
+
+        @Override
+        public int compareTo(Node o) {
+
+            // 최종 비용이 같은 경우 시간비용이 더 작은 것을 고름.
+            if(this.cost == o.cost){
+                Edge e1 = new Edge(Math.min(this.from,this.to),Math.max(this.from,this.to));
+                Edge e2 = new Edge(Math.min(o.from,o.to),Math.max(o.from,o.to));
+                long e1Cost = pathCost.get(e1);
+                long e2Cost = pathCost.get(e2);
+
+                if(((dist[o.from]*9)/10 + e2Cost) > ((dist[this.from]*9)/10 + e1Cost) ){
+                    return -1;
+                }
+                return 1;
+            }
+            if(this.cost > o.cost){
+                return 1;
+            }
+            return -1;
+        }
+    }
+
+
+    // 예제 입력 간선 저장용 그래프
+    static List<Node> graph[];
+
+    // timeGraph: timeGraph[i]: i 를 이전 노드로 가지는 인덱스 (ex: 1-> 2 로 간다면 timeGraph[1] 의 List 안에는 2가 존재 )
+    static List<Integer> timeGraph[];
+
+    //path[i] 는 i의 이전 노드의 인덱스 (1-> ... i -> path[i])
+    static int path[];
+
+    static int N;
+
+    // 비용 기록용 리스트 : costRecord[i] 는 1부터 i까지 비용 ( 단 각각의 간선마다 9/10 이 이미 적용된 상태)
+    static long costRecord[];
+
+    static class Edge{
+        private int from;
+        private int to;
+
+        public Edge(int from, int to) {
+            this.from = from;
+            this.to = to;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            Edge e = (Edge) obj;
+            if(this.from==e.from && this.to == e.to){
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(from,to);
+        }
+    }
+
+    // 특정 간선의 저장을 위한 Map
+    static Map<Edge,Long> pathCost = new HashMap<>();
+
+    static long answer = 0;
+
+
+    public static void main(String[] args) throws Exception {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        dist = new long[N+1];
+        graph = new List[N+1];
+        timeGraph = new List[N+1];
+        path = new int[N+1];
+        pathCost = new HashMap<>();
+        costRecord = new long[N+1];
+        Arrays.fill(costRecord,Long.MAX_VALUE);
+
+        for(int i=1;i<=N;i++){
+            graph[i] = new ArrayList<>();
+            timeGraph[i] = new ArrayList<>();
+        }
+
+        for(int i=0;i<M;i++){
+            st = new StringTokenizer(br.readLine());
+            int first = Integer.parseInt(st.nextToken());
+            int second = Integer.parseInt(st.nextToken());
+            long cost = Long.parseLong(st.nextToken());
+
+            graph[first].add(new Node(first,second,cost));
+            graph[second].add(new Node(second,first,cost));
+
+            // 추후 동일한 간선을 EqualsAndHashCode 로 찾기 위해 순서를 지정 .
+            pathCost.put(new Edge(Math.min(first,second),Math.max(first,second)),cost);
+        }
+
+        //1에서부터 N 번의 노드까지 최단 거리를 구함.
+        // 단 이 과정에서 최단 거리가 동일할 시
+        dijkstra(1);
+
+
+        costRecord[1] = 0;
+
+        // tiemGraph 초기화 : timeGraph[i] 의 리스트안에는 i 를 이전 노드로 하는 값이 들어있다.
+        for(int i=2;i<=N;i++){
+            timeGraph[path[i]].add(i);
+        }
+
+        BFS(1);
+
+        System.out.println(answer);
+
+
+    }
+
+
+    //다익스트라
+    public static void dijkstra(int start){
+        Arrays.fill(dist,Long.MAX_VALUE);
+        dist[start] = 0;
+        boolean isVisited[] = new boolean[N+1];
+
+        PriorityQueue<Node> pq = new PriorityQueue<>();
+        pq.add(new Node(start,start,0));
+
+        while(!pq.isEmpty()){
+            Node now = pq.poll();
+
+            if(isVisited[now.to]) continue;
+
+            isVisited[now.to] = true;
+
+            // path[i]에는 i의 이전 노드값이 들어가 있다. (1->... i-> i의 이전 노드값)
+            path[now.to] = now.from;
+
+            for(Node next : graph[now.to]){
+                // 거리가 같은 것도 PQ 에 넣음으로써 시간 비용이 작은 것을 먼저 꺼내도록 한다.
+                if(dist[next.to] >= dist[now.to] + next.cost){
+                    dist[next.to] = dist[now.to] + next.cost;
+                    pq.add(new Node(now.to,next.to,dist[next.to]));
+                }
+            }
+        }
+    }
+
+    // 1부터 BFS 시작
+    public static void BFS(int start){
+        Queue<Integer> queue = new LinkedList<>();
+        queue.add(start);
+        boolean isVisited[] = new boolean[N+1];
+
+        while(!queue.isEmpty()){
+            int nextIndex = queue.poll();
+
+            // 1을 이전 노드로 하는 인덱스를 꺼낸다.
+            for(int next : timeGraph[nextIndex]){
+
+                if(isVisited[next]){
+                    continue;
+                }
+                isVisited[next] = true;
+
+
+                long tmpSum = 0;
+                long tmp = 0;
+                int tmpStart = next;
+                while(true){
+                    if(tmpStart == 1){
+                        break;
+                    }
+                    if(costRecord[tmpStart] != Long.MAX_VALUE){
+                        tmpSum+=costRecord[tmpStart];
+                        tmp = costRecord[tmpStart];
+                        break;
+                    }
+
+                    int prev = path[tmpStart];
+                    Edge edge = new Edge(Math.min(prev,tmpStart),Math.max(prev,tmpStart));
+                    long cost = pathCost.get(edge);
+                    tmpSum += cost;
+                    tmpStart = prev;
+                }
+
+                // tmpSum의 의미: 특정 노드까지 가는 시간의 최솟값.
+                // tmp의 의미: 9/10 가 적용된 거리까지 시간의 최솟값.
+                // before 의 의미: 사실상 간선 비용 .
+                long before = tmpSum - tmp;
+
+                // costRecord 에는 각 시간 비용에 9/10가 모두 적용되어 있다. 따라서 나중에 메모이제이션 기법으로
+                // 이 값을 찾는다면 그냥 더해주기만 하면 된다.
+                costRecord[next] = tmp + (9*before)/10;
+                answer += tmpSum;
+                queue.add(next);
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
## ✍️작성자

> ex) 이진우

## 📝풀이 내용

> 문제 번호 + 풀이 내용 형식으로 작성해주세요.

### 17940 

- 다익스트라에서 PQ 를 활용
- PQ 는 환승횟수가 적은 것, 환승 횟수가 같다면 비용이 작은 것을 꺼내오도록 사용 
-  dist[i] : 출발점 부터 i 까지 갔을 때 최소 시간비용 , transferNum[i] : 출발점 부터 i까지 갔을 때 최소 환승 횟수 를 관리하여 다익스트라 과정 중 갱신이 용이하게 함.

### 20160

- 다익스라에서 PQ를 활용
- PQ는 비용이 제일 작은 것을 우선으로 둠
- 요구르트 아줌마의 판매 경로 배열을 저장한 이후, 특정 지점마다 몇초에 도착하는지 다익스트라를 활용하여 계산 
- 나의 위치에서 요구르트 아줌마의 방문 위치까지 걸리는 시간을 찾은 이후 그 값이 요구르트 아줌마가 걸리는 시간보다 작거나 같으면 그 INDEX 를 기록하여 최솟값을 구함.

### 31938

- 다익스트라에서 PQ를 활용
- PQ는 기본적으로 최단 거리가 짧은 순 , 최단거리가 같다면  그 노드까지의 시간비용이 더 짧은 것을 선택
- PQ 과정에서 특정 노드가 선택되었을 때 그 이전 노드를 함께 저장할 수 있게 하기위해 Node 에 from 값을 추가하였으며, 
이전 노드의 index 를 저장하기 위해 path 배열 사용 
- path 배열을 사용하여 timeGraph 초기화// timeGraph[3].add(5) 의 의미는 5의 이전 노드는 3이다. (이전 노드란 1->... i,i+1)이라면 i+1의 이전 노드는 i )
- 추후 이 timeGraph 를 BFS로 탐색하여 값을 계산 및 저장 . 






## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) BFS 내에서 시간 또는 메모리를 더 줄일 수 있을까요?
