### PR TITLE
[week9] 황지연

### DIFF
--- a/src/jiyeon/week9/boj_1052.java
+++ b/src/jiyeon/week9/boj_1052.java
@@ -1,0 +1,37 @@
+package jiyeon.week9;
+
+import java.io.*;
+import java.util.*;
+
+public class boj_1052 {
+	
+	static int N, K, count;
+
+	public static void main(String[] args) throws IOException{
+		
+		BufferedReader br = new BufferedReader (new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken()); 
+		//입력
+		
+		while(true) {
+			
+			int oneCount = Integer.bitCount(N); //1의 개수 
+			
+			if(oneCount<=K) {
+				break;
+			}
+			
+			int idx = Integer.numberOfTrailingZeros(N); //오른쪽부터 0의 위치를 탐색 -> 가장  오른쪽에 있는 0의 인덱스를 반환
+			N += 1<<idx;
+			count += 1<<idx;
+			
+		}
+		
+		System.out.println(count);
+
+	}//main
+
+}

--- a/src/jiyeon/week9/boj_10728.java
+++ b/src/jiyeon/week9/boj_10728.java
@@ -1,0 +1,121 @@
+package jiyeon.week9;
+
+import java.io.*;
+import java.util.*;
+
+public class boj_10728 {
+
+	
+	static int T,N,len, answer; //len : 제일 긴 수열 길이 / answer : 수열
+	static StringBuilder sb = new StringBuilder();
+	static HashSet<Integer> XORsubset = new HashSet<>(); //XOR 했을 떄 0이 되는 3개의 수를 저장하는 set
+
+	public static void main(String[] args) throws IOException{
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		T = Integer.parseInt(br.readLine());
+		
+
+		for(int t=1; t<=T; t++) {
+			
+			N = Integer.parseInt(br.readLine());
+			XORsubset.clear();
+			len = 0;
+			answer = 0;
+			
+			if(N==1) {
+				sb.append(1+"\n"+1+"\n");
+			}
+			else { 
+				genXOR(N);
+				
+				//모든 조합 탐색 
+				for(int i = 1; i<(1<<N); i++) {
+					
+					//조합의 크기가 현재 최대 수열의 길이보다 작거나 같다면 skip
+					if(len>= Integer.bitCount(i))
+						continue;
+					
+					//XOR결과 0이 되면 건너뛴다.
+					if(isIncluded(i)) {
+						continue;
+					}
+					else {
+						answer = i;
+						len = Math.max(len, Integer.bitCount(answer));
+					}
+				}
+				
+				sb.append(len).append("\n");
+				
+				//다시 10진수로 변환
+				for(int i=0 ; i<N; i++) {
+					if((answer & (1<<i)) != 0){
+						sb.append(i+1).append(" ");
+					}
+				}
+				sb.append("\n");
+				
+			}//if - else
+			
+			
+		}//testcase
+		
+		System.out.println(sb);
+
+	}//main
+	
+	//조합 중 3개를 뽑아서 XORsubset에 포함되는지 확인 하는 메소드 
+	static boolean isIncluded(int subset) {
+		
+		/*
+		 * 만약 subset이 110110이면 index 배열은 {1,2,4,5}
+		 * 
+		 * */
+		
+		ArrayList<Integer> index = new ArrayList<>(); //1들의 인덱스를 저장하는 배열
+		
+		for(int i=0; i<N; i++) {
+			if((subset & (1<<i)) !=0) {
+				index.add(i);
+			}
+		}
+		
+		int size = index.size();
+		
+		//index 배열에 저장된 수 중에 3개를 뽑아서 XORsubset과 비교 
+		for(int i=0; i<size; i++) {
+			for(int j=i+1; j<size; j++) {
+				for(int k=j+1; k<size; k++) {
+					
+					int set = (1<<index.get(i)) | (1<<index.get(j)) | (1<<index.get(k));
+					
+					if(XORsubset.contains(set)) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}//isEnabled
+	
+	
+	// 1~N 중에 3개를 뽑아서 XOR한 결과 0이 되는 조합 찾는 메소드
+	static void genXOR(int N) {
+		
+		for(int i=1; i<=N; i++) {
+			for(int j=i+1; j<=N; j++) {
+				for(int k=j+1; k<=N; k++) {
+					
+					if((i^j^k) == 0) {
+						int bit = (1<<(i-1)) | (1<<(j-1)) | (1<<(k-1)); //비트는 0번 옮기는게 1이기 때문에 -1을 해준다.
+						XORsubset.add(bit);
+					}
+				}
+			}
+		}
+		
+	}//genXOR
+	
+}

--- a/src/jiyeon/week9/boj_15661.java
+++ b/src/jiyeon/week9/boj_15661.java
@@ -1,0 +1,82 @@
+package jiyeon.week9;
+
+import java.io.*;
+import java.util.*;
+
+public class boj_15661 {
+	
+	/*
+	 * 조합을 구해서 -> 그 조합에 해당되는 사람들의 능력치 합과 아닌 사람의 능력치 합을 비교 -> 최소 차이를 출력
+	 * 비트마스킹으로 모든 조합을 구하자 
+	 * - 0이면 start 팀 
+	 * - 1이면 link 팀 
+	 * 
+	 * */
+	
+	static int N, startExp, linkExp, min; 
+	static int[][] exp;
+	static ArrayList<Integer> start = new ArrayList<>(); //start 팀에 속한 사람의 num
+	static ArrayList<Integer> link = new ArrayList<>(); //link 팀에 속한 사람의 num
+	
+	public static void main(String[] args) throws IOException{
+		
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		exp = new int[N][N];
+		
+		for(int i=0; i<N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for(int j=0; j<N; j++) {
+				exp[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}//입력
+		
+		min = Integer.MAX_VALUE;
+		
+		// 두 팀으로 나눠야하기 때문에 0000, 1111과 같은 경우는 제외한다.
+		for(int i=1; i<(1<<N)-1; i++) {
+			
+			startExp = 0;
+			linkExp = 0;
+			start.clear();
+			link.clear();
+			
+			for(int j=0; j<N; j++) {
+				if((i & (1<<j)) == 0) {
+					start.add(j);
+				}
+				else {
+					link.add(j);
+				}
+			}
+			
+			//각 팀의 점수 계산
+			startExp = getScore(start);
+			linkExp = getScore(link);
+			
+			int diff = Math.abs(startExp - linkExp);
+			min = Math.min(min, diff);
+			
+		}
+		
+		System.out.println(min);
+		
+		
+	}//main
+	
+	
+	//점수 계산하는 메소드 
+	static int getScore(ArrayList<Integer> list) {
+		int score = 0;
+		
+		for(int i=0; i<list.size(); i++) {
+			for(int j=i;j<list.size(); j++ ) {
+				score += exp[list.get(i)][list.get(j)];
+				score += exp[list.get(j)][list.get(i)];
+			}
+		}
+		
+		return score;
+	}//getScore
+
+}


### PR DESCRIPTION
## ✍️작성자

> 황지연

## 📝풀이 내용

> **1052번 물병**

1리터씩 들어있는 물병을 합쳐서 K개 이하로 만들고 싶다면 물병 개수를 2진수로 만들었을 때의 1의 개수가 K보다 작거나 같으면 된다. 
우리가 어렸을 적 즐겨하던 2048이라는 게임을 떠올리면 이해가 쉬울 것이다.

반복문을 돌면서 1의 개수를 체크한다. 
만약 1의 개수<=K 이면 break; 
아니라면 물병 개수 +=1을 해도 되지만 비효율적
=> 0인 자릿수를 1로 만들어주면 된다. 그러기 위해서는 제일 오른쪽에 위치한 0의 인덱스를 반환 받고, 그 만큼 물병 개수를 더 해주면 된다.

------
> **15661번 링크와 스타트**

링크 팀과 스타트 팀을 나눠주어야한다. 
N<=20이라는 조건이 있기때문에 비트마스킹으로 조합을 구할 수 있다. 
각 인덱스의 위치한 숫자를 해당 사람이 속한 팀이라고 생각하자. (0은 스타트 팀, 1은 링크 팀)
- 예를 들어 사람이 4명인데 1,3번 사람은 스타트팀이고 2,4번 사람은 링크 팀이라면 `1010`으로 표현할 수 있다.
- 여기서 주의할 점은 각 팀에 최소 1명 이상 배치되어야하기 때문에 0000 ... / 1111 ... 과 같이 모든 자리가 0 혹은 1로 이루어져있는 경우는 배제해주었다. 

이후 각 팀의 점수를 계산해주면된다! 끝

-------

> **10728번 XOR 삼형제 1**

비트마스킹으로 완탐하여 풀이하였다.
주요 로직은 다음과 같다.

1. 주어진 N을 입력 받고 1~N 중 3개의 원소를 뽑아 XOR의 결과가 0이면 HashSet에 저장한다.
2. 그 후 1~N 중 모든 원소 수열을 탐색한다. 
3. 수열 중에서 3개의 원소를 뽑아 HashSet과 비교한다. 만약 HashSet에 해당 원소가 들어있으면 XOR결과가 0이므로 건너뛴다.
3-1. 만약 contains의 결과가 false라면 조건을 만족하므로 저장한다. 
4. 이후 수열 탐색을 계속한다. 만약 수열의 길이가 정답 수열의 길이와 같거나 작다면 탐색할 필요가 없으므로 건너뛴다.

완탐해서 시간복잡도가 클 줄 알았는데 생각보다 비트마스킹의 효과가 좋은지 빠르게 되네요~ 괜한걱정~

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) BFS 내에서 시간 또는 메모리를 더 줄일 수 있을까요?
